### PR TITLE
Fix critical auth bypasses on admin API routes (#1 #2 #3 #4)

### DIFF
--- a/src/app/api/admin/auth/route.ts
+++ b/src/app/api/admin/auth/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-
-const ADMIN_COOKIE = 'av-admin-session'
+import { ADMIN_COOKIE, getAdminSessionToken } from '@/lib/admin-auth'
 
 export async function POST(request: NextRequest) {
   const { passphrase, next, rememberMe } = await request.json()
@@ -13,7 +12,7 @@ export async function POST(request: NextRequest) {
   const response = NextResponse.json({ ok: true, redirectTo })
 
   const useSecure = new URL(request.url).protocol === 'https:'
-  response.cookies.set(ADMIN_COOKIE, 'authenticated', {
+  response.cookies.set(ADMIN_COOKIE, getAdminSessionToken(), {
     httpOnly: true,
     secure: useSecure,
     sameSite: 'lax',
@@ -24,8 +23,8 @@ export async function POST(request: NextRequest) {
   return response
 }
 
-export async function DELETE(request: NextRequest) {
+export async function DELETE(_request: NextRequest) {
   const response = NextResponse.json({ ok: true })
-  response.cookies.delete('av-admin-session')
+  response.cookies.delete(ADMIN_COOKIE)
   return response
 }

--- a/src/app/api/admin/clients/impersonate/route.ts
+++ b/src/app/api/admin/clients/impersonate/route.ts
@@ -6,8 +6,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { encode } from 'next-auth/jwt'
 import { sql } from '@/lib/db'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 
 export async function POST(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
   const { clientId } = await request.json()
 
   if (!clientId) {

--- a/src/app/api/admin/clients/invite/route.ts
+++ b/src/app/api/admin/clients/invite/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sendMagicLink } from '@/lib/send-magic-link'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 
 export async function POST(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
   const { email } = await request.json()
 
   if (!email) {

--- a/src/app/api/admin/clients/route.ts
+++ b/src/app/api/admin/clients/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sql } from '@/lib/db'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
   const clients = await sql`
     SELECT id, name, contact_name, email, phone, created_at
     FROM clients
@@ -11,6 +14,8 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
   const { name, contact_name, email, phone } = await request.json()
 
   const rows = await sql`

--- a/src/app/api/admin/documents/route.ts
+++ b/src/app/api/admin/documents/route.ts
@@ -1,14 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sql } from '@/lib/db'
-
-const ADMIN_COOKIE = 'av-admin-session'
-
-function isAdmin(request: NextRequest) {
-  return request.cookies.get(ADMIN_COOKIE)?.value === 'authenticated'
-}
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 
 export async function GET(request: NextRequest) {
-  if (!isAdmin(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!isAdmin(request)) return unauthorizedResponse()
 
   const docs = await sql`
     SELECT d.id, d.client_id, d.title, d.updated_at,
@@ -22,7 +17,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  if (!isAdmin(request)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!isAdmin(request)) return unauthorizedResponse()
 
   const { client_id, title, content } = await request.json()
 

--- a/src/app/api/admin/projects/route.ts
+++ b/src/app/api/admin/projects/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { sql } from '@/lib/db'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
   const projects = await sql`
     SELECT p.id, p.name, p.status, p.current_phase, p.start_date,
            p.phase_proposal_date, p.phase_kickoff_date, p.phase_design_date,
@@ -15,6 +18,8 @@ export async function GET() {
 }
 
 export async function PATCH(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
   const { id, current_phase, phase_proposal_date, phase_kickoff_date, phase_design_date,
           phase_development_date, phase_review_date, phase_launched_date } = await request.json()
 

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const ADMIN_COOKIE = 'av-admin-session'
+
+/**
+ * Returns true if the request carries a valid admin session cookie.
+ * The cookie is set by POST /api/admin/auth after passphrase verification.
+ */
+export function isAdmin(request: NextRequest): boolean {
+  return request.cookies.get(ADMIN_COOKIE)?.value === 'authenticated'
+}
+
+/** Standard 401 response for unauthenticated admin requests. */
+export function unauthorizedResponse(): NextResponse {
+  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+}

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -1,13 +1,26 @@
+import { createHmac } from 'crypto'
 import { NextRequest, NextResponse } from 'next/server'
 
-const ADMIN_COOKIE = 'av-admin-session'
+export const ADMIN_COOKIE = 'av-admin-session'
+
+/**
+ * Returns the expected admin session token — an HMAC-SHA256 of the fixed
+ * string "admin-session" keyed by ADMIN_PASSPHRASE.  A fixed-string cookie
+ * value ("authenticated") is trivially forgeable; using HMAC ties validity
+ * to knowledge of the passphrase without storing it in the cookie itself.
+ */
+export function getAdminSessionToken(): string {
+  return createHmac('sha256', process.env.ADMIN_PASSPHRASE ?? '')
+    .update('admin-session')
+    .digest('hex')
+}
 
 /**
  * Returns true if the request carries a valid admin session cookie.
  * The cookie is set by POST /api/admin/auth after passphrase verification.
  */
 export function isAdmin(request: NextRequest): boolean {
-  return request.cookies.get(ADMIN_COOKIE)?.value === 'authenticated'
+  return request.cookies.get(ADMIN_COOKIE)?.value === getAdminSessionToken()
 }
 
 /** Standard 401 response for unauthenticated admin requests. */

--- a/tests/integration/admin-auth.test.ts
+++ b/tests/integration/admin-auth.test.ts
@@ -1,0 +1,273 @@
+import { createHmac } from 'crypto'
+import { NextRequest } from 'next/server'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_PASSPHRASE = 'super-secret-test-passphrase'
+
+function hmacToken(passphrase: string): string {
+  return createHmac('sha256', passphrase).update('admin-session').digest('hex')
+}
+
+/** Build a NextRequest with an optional av-admin-session cookie. */
+function makeAdminRequest(
+  url: string,
+  method = 'GET',
+  cookieValue?: string,
+): NextRequest {
+  const headers: Record<string, string> = {}
+  if (cookieValue !== undefined) {
+    headers['Cookie'] = `av-admin-session=${cookieValue}`
+  }
+  return new NextRequest(url, { method, headers })
+}
+
+// ---------------------------------------------------------------------------
+// Tests: admin-auth helpers (unit)
+// ---------------------------------------------------------------------------
+
+describe('getAdminSessionToken()', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('returns hex HMAC-SHA256 of "admin-session" keyed by ADMIN_PASSPHRASE', async () => {
+    vi.stubEnv('ADMIN_PASSPHRASE', TEST_PASSPHRASE)
+    const { getAdminSessionToken } = await import('@/lib/admin-auth')
+    expect(getAdminSessionToken()).toBe(hmacToken(TEST_PASSPHRASE))
+  })
+
+  it('returns a different token when ADMIN_PASSPHRASE changes', async () => {
+    vi.stubEnv('ADMIN_PASSPHRASE', 'passphrase-a')
+    const { getAdminSessionToken: tokenA } = await import('@/lib/admin-auth')
+    const a = tokenA()
+
+    vi.stubEnv('ADMIN_PASSPHRASE', 'passphrase-b')
+    vi.resetModules()
+    const { getAdminSessionToken: tokenB } = await import('@/lib/admin-auth')
+    const b = tokenB()
+
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('isAdmin()', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('ADMIN_PASSPHRASE', TEST_PASSPHRASE)
+  })
+
+  it('returns true when cookie carries the correct HMAC token', async () => {
+    const { isAdmin } = await import('@/lib/admin-auth')
+    const req = makeAdminRequest(
+      'http://localhost/admin',
+      'GET',
+      hmacToken(TEST_PASSPHRASE),
+    )
+    expect(isAdmin(req)).toBe(true)
+  })
+
+  it('returns false when cookie is absent', async () => {
+    const { isAdmin } = await import('@/lib/admin-auth')
+    const req = makeAdminRequest('http://localhost/admin')
+    expect(isAdmin(req)).toBe(false)
+  })
+
+  it('returns false for the legacy fixed string "authenticated"', async () => {
+    const { isAdmin } = await import('@/lib/admin-auth')
+    const req = makeAdminRequest('http://localhost/admin', 'GET', 'authenticated')
+    expect(isAdmin(req)).toBe(false)
+  })
+
+  it('returns false for an arbitrary wrong token', async () => {
+    const { isAdmin } = await import('@/lib/admin-auth')
+    const req = makeAdminRequest(
+      'http://localhost/admin',
+      'GET',
+      'deadbeefdeadbeef',
+    )
+    expect(isAdmin(req)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: POST /api/admin/auth
+// ---------------------------------------------------------------------------
+
+describe('POST /api/admin/auth', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('ADMIN_PASSPHRASE', TEST_PASSPHRASE)
+  })
+
+  it('returns 401 when passphrase is wrong', async () => {
+    const { POST } = await import('@/app/api/admin/auth/route')
+    const req = new NextRequest('http://localhost/api/admin/auth', {
+      method: 'POST',
+      body: JSON.stringify({ passphrase: 'wrong-passphrase' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when passphrase is missing', async () => {
+    const { POST } = await import('@/app/api/admin/auth/route')
+    const req = new NextRequest('http://localhost/api/admin/auth', {
+      method: 'POST',
+      body: JSON.stringify({}),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 and sets HMAC cookie on correct passphrase', async () => {
+    const { POST } = await import('@/app/api/admin/auth/route')
+    const req = new NextRequest('http://localhost/api/admin/auth', {
+      method: 'POST',
+      body: JSON.stringify({ passphrase: TEST_PASSPHRASE }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+
+    // Cookie must carry the HMAC token, not the bare string 'authenticated'
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    const expectedToken = hmacToken(TEST_PASSPHRASE)
+    expect(setCookie).toContain(`av-admin-session=${expectedToken}`)
+    expect(setCookie).not.toContain('authenticated')
+  })
+
+  it('redirects to /admin/clients by default', async () => {
+    const { POST } = await import('@/app/api/admin/auth/route')
+    const req = new NextRequest('http://localhost/api/admin/auth', {
+      method: 'POST',
+      body: JSON.stringify({ passphrase: TEST_PASSPHRASE }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    const body = await res.json()
+    expect(body.redirectTo).toBe('/admin/clients')
+  })
+
+  it('respects a safe `next` redirect within /admin', async () => {
+    const { POST } = await import('@/app/api/admin/auth/route')
+    const req = new NextRequest('http://localhost/api/admin/auth', {
+      method: 'POST',
+      body: JSON.stringify({ passphrase: TEST_PASSPHRASE, next: '/admin/invoices' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    const body = await res.json()
+    expect(body.redirectTo).toBe('/admin/invoices')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: admin resource routes — must return 401 without valid cookie
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/db', () => ({
+  sql: new Proxy(
+    async () => [],
+    {
+      get: (_target, prop) => {
+        if (prop === 'then') return undefined // prevent auto-await
+        return async () => []
+      },
+    },
+  ),
+}))
+
+describe('GET /api/admin/clients — 401 guard', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('ADMIN_PASSPHRASE', TEST_PASSPHRASE)
+  })
+
+  it('returns 401 with no cookie', async () => {
+    const { GET } = await import('@/app/api/admin/clients/route')
+    const req = makeAdminRequest('http://localhost/api/admin/clients')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 with the legacy "authenticated" cookie value', async () => {
+    const { GET } = await import('@/app/api/admin/clients/route')
+    const req = makeAdminRequest(
+      'http://localhost/api/admin/clients',
+      'GET',
+      'authenticated',
+    )
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 with a random wrong token', async () => {
+    const { GET } = await import('@/app/api/admin/clients/route')
+    const req = makeAdminRequest(
+      'http://localhost/api/admin/clients',
+      'GET',
+      'not-a-valid-token',
+    )
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('GET /api/admin/projects — 401 guard', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('ADMIN_PASSPHRASE', TEST_PASSPHRASE)
+  })
+
+  it('returns 401 with no cookie', async () => {
+    const { GET } = await import('@/app/api/admin/projects/route')
+    const req = makeAdminRequest('http://localhost/api/admin/projects')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 with the legacy "authenticated" cookie value', async () => {
+    const { GET } = await import('@/app/api/admin/projects/route')
+    const req = makeAdminRequest(
+      'http://localhost/api/admin/projects',
+      'GET',
+      'authenticated',
+    )
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+})
+
+describe('GET /api/admin/documents — 401 guard', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('ADMIN_PASSPHRASE', TEST_PASSPHRASE)
+  })
+
+  it('returns 401 with no cookie', async () => {
+    const { GET } = await import('@/app/api/admin/documents/route')
+    const req = makeAdminRequest('http://localhost/api/admin/documents')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 with the legacy "authenticated" cookie value', async () => {
+    const { GET } = await import('@/app/api/admin/documents/route')
+    const req = makeAdminRequest(
+      'http://localhost/api/admin/documents',
+      'GET',
+      'authenticated',
+    )
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+})


### PR DESCRIPTION
Superseded by #22 — rebased onto main with all three Copilot comments addressed + HMAC cookie hardening. Closing this to clear the merge conflict.