### PR TITLE
Fix broken mailto on capabilities page + form error states

### DIFF
--- a/src/app/capabilities/page.tsx
+++ b/src/app/capabilities/page.tsx
@@ -2,7 +2,6 @@ import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import FadeIn from "@/components/FadeIn";
 import { SITE, SAM } from "@/lib/constants";
-import EmailLink from "@/components/EmailLink";
 import CapabilityRequestForm from "@/components/CapabilityRequestForm";
 
 export const metadata = {
@@ -130,12 +129,12 @@ export default function CapabilitiesPage() {
                 {
                   label: "Primary Contact",
                   value: (
-                    <EmailLink
-                      account="marston"
+                    <a
+                      href="/contact"
                       className="text-blue-400 hover:text-blue-300 transition underline underline-offset-2"
                     >
-                      Email
-                    </EmailLink>
+                      Contact form
+                    </a>
                   ),
                 },
               ] as { label: string; value: React.ReactNode }[]).map((item) => (

--- a/src/components/CapabilityRequestForm.tsx
+++ b/src/components/CapabilityRequestForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { ArrowDownTrayIcon, CheckIcon } from "@heroicons/react/24/outline";
 
-type Status = "idle" | "open" | "sending" | "sent" | "error";
+type Status = "idle" | "open" | "sending" | "sent" | "error" | "unconfigured";
 
 export default function CapabilityRequestForm({
   compact = false,
@@ -31,7 +31,13 @@ export default function CapabilityRequestForm({
           _gotcha: honeypot,
         }),
       });
-      setStatus(res.ok ? "sent" : "error");
+      if (res.ok) {
+        setStatus("sent");
+      } else if (res.status === 503) {
+        setStatus("unconfigured");
+      } else {
+        setStatus("error");
+      }
     } catch {
       setStatus("error");
     }
@@ -105,7 +111,15 @@ export default function CapabilityRequestForm({
         <p className="text-red-400 text-xs w-full sm:w-auto self-center">
           Something went wrong.{" "}
           <a href="/contact" className="underline hover:text-red-300">
-            Try the contact page.
+            Use the contact page.
+          </a>
+        </p>
+      )}
+      {status === "unconfigured" && (
+        <p className="text-yellow-400 text-xs w-full sm:w-auto self-center">
+          Form not configured yet.{" "}
+          <a href="/contact" className="underline hover:text-yellow-300">
+            Use the contact page.
           </a>
         </p>
       )}

--- a/tests/unit/CapabilityRequestForm.test.tsx
+++ b/tests/unit/CapabilityRequestForm.test.tsx
@@ -60,6 +60,26 @@ describe("CapabilityRequestForm", () => {
     vi.unstubAllGlobals();
   });
 
+  it("shows the unconfigured warning when the API returns 503", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503, json: () => Promise.resolve({ error: "unconfigured" }) })
+    );
+
+    render(<CapabilityRequestForm />);
+    fireEvent.click(screen.getByRole("button", { name: /request pdf/i }));
+    fireEvent.change(screen.getByLabelText(/your name/i), { target: { value: "Jane" } });
+    fireEvent.change(screen.getByLabelText(/your email/i), { target: { value: "jane@test.com" } });
+    fireEvent.submit(screen.getByLabelText(/your name/i).closest("form")!);
+
+    await waitFor(() =>
+      expect(screen.getByText(/form not configured yet/i)).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+
+    vi.unstubAllGlobals();
+  });
+
   it("POSTs to /api/contact with the correct pre-filled subject and message", async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary

- **Primary Contact link**: The "Email" link in the capabilities snapshot table was an `EmailLink` (mailto:) — broken for users without a mail client. Changed to a plain link to `/contact`.
- **Unused import**: Removed `EmailLink` import from capabilities page (no longer used there).
- **Form error states**: `CapabilityRequestForm` now distinguishes a 503 (form not configured / `NEXT_PUBLIC_FORMSPREE_ID` not set in Vercel) from other errors, showing a yellow "Form not configured yet" warning instead of the generic red error.

## Root cause of the form error

The capabilities PDF request form returns 503 when `NEXT_PUBLIC_FORMSPREE_ID` is not set in the Vercel environment. To fix:
1. Vercel → aetheris-vision-website → Settings → Environment Variables
2. Confirm `NEXT_PUBLIC_FORMSPREE_ID` is set to a valid Formspree form ID
3. Redeploy

## Test plan

- [x] 162 tests pass
- [ ] Verify Primary Contact on /capabilities links to /contact page
- [ ] Verify form shows yellow warning (not red error) when Formspree not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)