### PR TITLE
Guard expense APIs with admin auth + expand cron vendors

### DIFF
--- a/scripts/import-expenses-2026.mjs
+++ b/scripts/import-expenses-2026.mjs
@@ -1,0 +1,106 @@
+/**
+ * One-time backfill: imports receipts_2026.csv from the aetherisvision repo
+ * into the Neon expenses table, skipping rows that are already present
+ * (matched by date + vendor + amount).
+ *
+ * Usage:
+ *   DATABASE_URL=<neon-url> node scripts/import-expenses-2026.mjs
+ *   -- or --
+ *   source ~/.secrets && node scripts/import-expenses-2026.mjs
+ *
+ * The script is idempotent — safe to run multiple times.
+ */
+
+import { readFileSync } from 'fs'
+import { neon } from '@neondatabase/serverless'
+
+const CSV_PATH =
+  '/Users/marston.ward/Documents/GitHub/aetherisvision/receipts/receipts_2026.csv'
+
+const DATABASE_URL = process.env.DATABASE_URL
+if (!DATABASE_URL) {
+  console.error('DATABASE_URL is not set. Source ~/.secrets first.')
+  process.exit(1)
+}
+
+const sql = neon(DATABASE_URL)
+
+// Normalise category names from the CSV to match the admin UI's CATEGORIES list
+const CATEGORY_MAP = {
+  'Software/SaaS':  'Software Subscriptions',
+  'AI/API':         'Cloud Services',
+  'Hosting':        'Domain & Hosting',
+  'Shipping':       'Office Supplies',
+  'Security':       'Software Subscriptions',
+  'Equipment':      'Equipment & Hardware',
+}
+
+function normaliseCategory(raw) {
+  return CATEGORY_MAP[raw?.trim()] ?? raw?.trim() ?? 'Other'
+}
+
+function parseCSV(text) {
+  const lines = text.trim().split('\n')
+  const headers = lines[0].split(',').map(h => h.trim())
+  return lines.slice(1).map(line => {
+    // Handle quoted fields
+    const fields = []
+    let cur = ''
+    let inQuote = false
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i]
+      if (ch === '"') { inQuote = !inQuote }
+      else if (ch === ',' && !inQuote) { fields.push(cur.trim()); cur = '' }
+      else { cur += ch }
+    }
+    fields.push(cur.trim())
+    return Object.fromEntries(headers.map((h, i) => [h, fields[i] ?? '']))
+  })
+}
+
+async function main() {
+  const csv = readFileSync(CSV_PATH, 'utf-8')
+  const rows = parseCSV(csv)
+
+  let inserted = 0
+  let skipped = 0
+
+  for (const row of rows) {
+    const date = row['Date']?.trim()
+    const vendor = row['Vendor']?.trim()
+    const rawAmount = row['Amount']?.replace('$', '').trim()
+    const amount = parseFloat(rawAmount)
+    const description = row['Description']?.trim() || vendor
+    const category = normaliseCategory(row['Category'])
+    const taxYear = date ? new Date(date).getFullYear() : 2026
+
+    if (!date || !vendor || isNaN(amount) || amount <= 0) {
+      console.log(`  skip (incomplete): ${JSON.stringify(row)}`)
+      skipped++
+      continue
+    }
+
+    // Check for existing row by date + vendor + amount
+    const existing = await sql`
+      SELECT id FROM expenses
+      WHERE date = ${date} AND vendor = ${vendor} AND amount = ${amount}
+      LIMIT 1
+    `
+    if (existing.length > 0) {
+      console.log(`  skip (exists):  ${date}  ${vendor}  $${amount.toFixed(2)}`)
+      skipped++
+      continue
+    }
+
+    await sql`
+      INSERT INTO expenses (date, vendor, description, category, amount, tax_year, source)
+      VALUES (${date}, ${vendor}, ${description}, ${category}, ${amount}, ${taxYear}, 'csv-import')
+    `
+    console.log(`  inserted:       ${date}  ${vendor}  $${amount.toFixed(2)}  [${category}]`)
+    inserted++
+  }
+
+  console.log(`\nDone. inserted=${inserted}  skipped=${skipped}`)
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/scripts/import-expenses-2026.mjs
+++ b/scripts/import-expenses-2026.mjs
@@ -4,18 +4,23 @@
  * (matched by date + vendor + amount).
  *
  * Usage:
- *   DATABASE_URL=<neon-url> node scripts/import-expenses-2026.mjs
+ *   DATABASE_URL=<neon-url> node scripts/import-expenses-2026.mjs [path/to/receipts.csv]
  *   -- or --
- *   source ~/.secrets && node scripts/import-expenses-2026.mjs
+ *   source ~/.secrets && EXPENSES_CSV=path/to/receipts.csv node scripts/import-expenses-2026.mjs
+ *
+ * CSV path resolution order: 1) first CLI arg, 2) EXPENSES_CSV env var,
+ * 3) ./receipts_2026.csv relative to the current working directory.
  *
  * The script is idempotent — safe to run multiple times.
  */
 
 import { readFileSync } from 'fs'
+import { resolve } from 'path'
 import { neon } from '@neondatabase/serverless'
 
-const CSV_PATH =
-  '/Users/marston.ward/Documents/GitHub/aetherisvision/receipts/receipts_2026.csv'
+const CSV_PATH = resolve(
+  process.argv[2] || process.env.EXPENSES_CSV || 'receipts_2026.csv'
+)
 
 const DATABASE_URL = process.env.DATABASE_URL
 if (!DATABASE_URL) {
@@ -49,7 +54,11 @@ function parseCSV(text) {
     let inQuote = false
     for (let i = 0; i < line.length; i++) {
       const ch = line[i]
-      if (ch === '"') { inQuote = !inQuote }
+      if (ch === '"') {
+        // RFC4180: a doubled quote inside a quoted field is a literal quote
+        if (inQuote && line[i + 1] === '"') { cur += '"'; i++ }
+        else { inQuote = !inQuote }
+      }
       else if (ch === ',' && !inQuote) { fields.push(cur.trim()); cur = '' }
       else { cur += ch }
     }
@@ -68,7 +77,9 @@ async function main() {
   for (const row of rows) {
     const date = row['Date']?.trim()
     const vendor = row['Vendor']?.trim()
-    const rawAmount = row['Amount']?.replace('$', '').trim()
+    // Strip currency symbols, thousands separators, and whitespace
+    // so values like "$1,234.56" parse correctly.
+    const rawAmount = row['Amount']?.replace(/[$,\s]/g, '')
     const amount = parseFloat(rawAmount)
     const description = row['Description']?.trim() || vendor
     const category = normaliseCategory(row['Category'])

--- a/src/app/admin/expenses/page.tsx
+++ b/src/app/admin/expenses/page.tsx
@@ -36,6 +36,7 @@ const CATEGORIES = [
   'Banking & Financial Fees',
   'Equipment & Hardware',
   'Office Supplies',
+  'Home Office',
   'Travel & Transportation',
   'Other',
 ]

--- a/src/app/api/cron/receipts/route.ts
+++ b/src/app/api/cron/receipts/route.ts
@@ -58,9 +58,17 @@ const VENDORS: [string, string, string][] = [
   ['PayPal',     'mail.paypal.com',     'Banking & Financial Fees'],
   ['Best Buy',   'bestbuy.com',         'Office & Equipment'],
   ['Best Buy',   'emails.bestbuy.com',  'Office & Equipment'],
-  ['Sanity',     'sanity.io',           'Cloud Services'],
-  ['Sanity',     'sanity-mail.com',     'Cloud Services'],
-  ['GitLab',     'gitlab.com',          'Cloud Services'],
+  ['Sanity',       'sanity.io',               'Cloud Services'],
+  ['Sanity',       'sanity-mail.com',         'Cloud Services'],
+  ['GitLab',       'gitlab.com',              'Cloud Services'],
+  // AI providers
+  ['xAI',          'x.ai',                    'Cloud Services'],
+  // Office / mailbox
+  ['Ship It Sooner', 'notify.postalmate.net', 'Office Supplies'],
+  // Security monitoring
+  ['AVS Concepts', 'billpay.systems',         'Software Subscriptions'],
+  // Professional certifications (AMS CCM exam, etc.)
+  ['AMS',          'ametsoc.org',             'Professional Certifications'],
 ]
 
 async function getAccessToken(refreshToken: string): Promise<string> {

--- a/src/app/api/expenses/[id]/route.ts
+++ b/src/app/api/expenses/[id]/route.ts
@@ -1,10 +1,12 @@
 import { sql } from '@/lib/db'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  if (!isAdmin(request)) return unauthorizedResponse()
   const { id } = await params
   const { date, vendor, description, category, amount, receipt_url } = await request.json()
 
@@ -28,6 +30,7 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  if (!isAdmin(request)) return unauthorizedResponse()
   const { id } = await params
   await sql`DELETE FROM expenses WHERE id = ${Number(id)}`
   return NextResponse.json({ ok: true })

--- a/src/app/api/expenses/route.ts
+++ b/src/app/api/expenses/route.ts
@@ -1,7 +1,9 @@
 import { sql } from '@/lib/db'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
   const { searchParams } = new URL(request.url)
   const taxYear = searchParams.get('tax_year') || new Date().getFullYear()
 
@@ -23,6 +25,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
   const body = await request.json()
   const { date, vendor, description, category, amount, tax_year, receipt_url } = body
 

--- a/tests/integration/admin-auth.test.ts
+++ b/tests/integration/admin-auth.test.ts
@@ -176,7 +176,9 @@ describe('POST /api/admin/auth', () => {
 
 vi.mock('@/lib/db', () => ({
   sql: new Proxy(
-    async () => [],
+    // Return one serializable row so authorized handlers that use
+    // `INSERT ... RETURNING *` (result[0]) can build a JSON response.
+    async () => [{ id: 1, vendor: 'Test', amount: 10, tax_year: 2026 }],
     {
       get: (_target, prop) => {
         if (prop === 'then') return undefined // prevent auto-await
@@ -269,5 +271,115 @@ describe('GET /api/admin/documents — 401 guard', () => {
     )
     const res = await GET(req)
     expect(res.status).toBe(401)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: /api/expenses and /api/expenses/[id] — admin guard
+// ---------------------------------------------------------------------------
+
+describe('/api/expenses — admin guard', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('ADMIN_PASSPHRASE', TEST_PASSPHRASE)
+  })
+
+  it('GET returns 401 with no cookie', async () => {
+    const { GET } = await import('@/app/api/expenses/route')
+    const res = await GET(makeAdminRequest('http://localhost/api/expenses'))
+    expect(res.status).toBe(401)
+  })
+
+  it('GET returns 401 with the legacy "authenticated" cookie value', async () => {
+    const { GET } = await import('@/app/api/expenses/route')
+    const res = await GET(
+      makeAdminRequest('http://localhost/api/expenses', 'GET', 'authenticated'),
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('GET succeeds (not 401) with a valid admin cookie', async () => {
+    const { GET } = await import('@/app/api/expenses/route')
+    const res = await GET(
+      makeAdminRequest('http://localhost/api/expenses', 'GET', hmacToken(TEST_PASSPHRASE)),
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('POST returns 401 with no cookie', async () => {
+    const { POST } = await import('@/app/api/expenses/route')
+    const req = new NextRequest('http://localhost/api/expenses', {
+      method: 'POST',
+      body: JSON.stringify({ vendor: 'Test' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('POST is allowed (not 401) with a valid admin cookie', async () => {
+    const { POST } = await import('@/app/api/expenses/route')
+    const req = new NextRequest('http://localhost/api/expenses', {
+      method: 'POST',
+      body: JSON.stringify({ vendor: 'Test', amount: 10, tax_year: 2026 }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `av-admin-session=${hmacToken(TEST_PASSPHRASE)}`,
+      },
+    })
+    const res = await POST(req)
+    expect(res.status).not.toBe(401)
+  })
+})
+
+describe('/api/expenses/[id] — admin guard', () => {
+  const params = Promise.resolve({ id: '1' })
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('ADMIN_PASSPHRASE', TEST_PASSPHRASE)
+  })
+
+  it('PATCH returns 401 with no cookie', async () => {
+    const { PATCH } = await import('@/app/api/expenses/[id]/route')
+    const req = new NextRequest('http://localhost/api/expenses/1', {
+      method: 'PATCH',
+      body: JSON.stringify({ vendor: 'Edit' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PATCH(req, { params })
+    expect(res.status).toBe(401)
+  })
+
+  it('PATCH is allowed (not 401) with a valid admin cookie', async () => {
+    const { PATCH } = await import('@/app/api/expenses/[id]/route')
+    const req = new NextRequest('http://localhost/api/expenses/1', {
+      method: 'PATCH',
+      body: JSON.stringify({ vendor: 'Edit' }),
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `av-admin-session=${hmacToken(TEST_PASSPHRASE)}`,
+      },
+    })
+    const res = await PATCH(req, { params })
+    expect(res.status).not.toBe(401)
+  })
+
+  it('DELETE returns 401 with no cookie', async () => {
+    const { DELETE } = await import('@/app/api/expenses/[id]/route')
+    const req = makeAdminRequest('http://localhost/api/expenses/1', 'DELETE')
+    const res = await DELETE(req, { params })
+    expect(res.status).toBe(401)
+  })
+
+  it('DELETE succeeds (not 401) with a valid admin cookie', async () => {
+    const { DELETE } = await import('@/app/api/expenses/[id]/route')
+    const req = makeAdminRequest(
+      'http://localhost/api/expenses/1',
+      'DELETE',
+      hmacToken(TEST_PASSPHRASE),
+    )
+    const res = await DELETE(req, { params })
+    expect(res.status).not.toBe(401)
   })
 })


### PR DESCRIPTION
## Summary
- **Security fix:** Add `isAdmin()` guards to the expense API routes. `/api/expenses` (GET/POST) and `/api/expenses/[id]` (PATCH/DELETE) were previously unauthenticated, exposing read and write access to business expense records. They now return 401 via `unauthorizedResponse()` for non-admin requests.
- Expand the Gmail receipt cron `VENDORS` allowlist (xAI, Ship It Sooner, AVS Concepts, AMS) and align table formatting.
- Add a "Home Office" category to the admin expenses UI.
- Add `scripts/import-expenses-2026.mjs` — an idempotent one-time backfill that imports `receipts_2026.csv` into the Neon `expenses` table, deduping by date + vendor + amount.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors (24 pre-existing warnings, none new; within CI `--max-warnings=24`)
- [ ] CI: ESLint + TypeScript + Unit Tests + Next.js Build + Vercel all green
- [ ] Manual: confirm `/api/expenses` returns 401 without the admin cookie and works in `/admin/expenses`

Made with [Cursor](https://cursor.com)