### PR TITLE
feat(auth): migrate next-auth v4 → v5 (Auth.js) — HOLD: manual auth verification required

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "isomorphic-dompurify": "^3.14.0",
         "marked": "^17.0.4",
         "next": "16.2.7",
-        "next-auth": "^5.0.0-beta.31",
+        "next-auth": "5.0.0-beta.31",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "isomorphic-dompurify": "^3.14.0",
         "marked": "^17.0.4",
         "next": "16.2.7",
-        "next-auth": "^4.24.13",
+        "next-auth": "^5.0.0-beta.31",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
@@ -170,6 +170,35 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -5396,15 +5425,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -8334,9 +8354,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -10237,30 +10257,25 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.14",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.14.tgz",
-      "integrity": "sha512-YRz6xFDXKUwiXSMMChbrBEWyFktZ1qZXEgeSHQQ3nsy08B4c/xLk6REeutRsIFwkjY/1+ShHnu07DN3JeJguig==",
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
       "license": "ISC",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.7.0",
-        "jose": "^4.15.5",
-        "oauth": "^0.9.15",
-        "openid-client": "^5.4.0",
-        "preact": "^10.6.3",
-        "preact-render-to-string": "^5.1.19",
-        "uuid": "^8.3.2"
+        "@auth/core": "0.41.2"
       },
       "peerDependencies": {
-        "@auth/core": "0.34.3",
-        "next": "^12.2.5 || ^13 || ^14 || ^15 || ^16",
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
         "nodemailer": "^7.0.7",
-        "react": "^17.0.2 || ^18 || ^19",
-        "react-dom": "^17.0.2 || ^18 || ^19"
+        "react": "^18.2.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
-        "@auth/core": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
           "optional": true
         },
         "nodemailer": {
@@ -10342,11 +10357,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
-      "license": "MIT"
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -10356,15 +10374,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -10491,15 +10500,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/oidc-token-hash": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
-      "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10508,39 +10508,6 @@
       "dependencies": {
         "wrappy": "1"
       }
-    },
-    "node_modules/openid-client": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
-      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^4.15.9",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/openid-client/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/openid-client/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -10952,9 +10919,9 @@
       "license": "ISC"
     },
     "node_modules/preact": {
-      "version": "10.29.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.0.tgz",
-      "integrity": "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==",
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -10962,22 +10929,13 @@
       }
     },
     "node_modules/preact-render-to-string": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
-      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
       "license": "MIT",
-      "dependencies": {
-        "pretty-format": "^3.8.0"
-      },
       "peerDependencies": {
         "preact": ">=10"
       }
-    },
-    "node_modules/preact-render-to-string/node_modules/pretty-format": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
-      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
-      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -13927,12 +13885,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "isomorphic-dompurify": "^3.14.0",
     "marked": "^17.0.4",
     "next": "16.2.7",
-    "next-auth": "^4.24.13",
+    "next-auth": "^5.0.0-beta.31",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
@@ -84,6 +84,7 @@
     "lightningcss-darwin-x64": "1.31.1"
   },
   "overrides": {
-    "postcss": "8.5.15"
+    "postcss": "8.5.15",
+    "uuid": "^11.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "isomorphic-dompurify": "^3.14.0",
     "marked": "^17.0.4",
     "next": "16.2.7",
-    "next-auth": "^5.0.0-beta.31",
+    "next-auth": "5.0.0-beta.31",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",

--- a/src/app/api/admin/clients/impersonate/route.ts
+++ b/src/app/api/admin/clients/impersonate/route.ts
@@ -7,7 +7,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { encode } from 'next-auth/jwt'
 import { sql } from '@/lib/db'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
-import { AUTH_SECRET, isSecureRequest, sessionCookieName } from '@/lib/auth-cookie'
+import { isSecureRequest, requireAuthSecret, sessionCookieName } from '@/lib/auth-cookie'
 
 export async function POST(request: NextRequest) {
   if (!isAdmin(request)) return unauthorizedResponse()
@@ -33,8 +33,15 @@ export async function POST(request: NextRequest) {
   const useSecure = isSecureRequest(request.url)
   const cookieName = sessionCookieName(useSecure)
 
+  let secret: string
+  try {
+    secret = requireAuthSecret()
+  } catch {
+    return NextResponse.json({ error: 'Auth secret not configured' }, { status: 500 })
+  }
+
   const sessionToken = await encode({
-    secret: AUTH_SECRET!,
+    secret,
     salt: cookieName,
     token: {
       email: client.email as string,

--- a/src/app/api/admin/clients/impersonate/route.ts
+++ b/src/app/api/admin/clients/impersonate/route.ts
@@ -7,6 +7,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { encode } from 'next-auth/jwt'
 import { sql } from '@/lib/db'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
+import { AUTH_SECRET, isSecureRequest, sessionCookieName } from '@/lib/auth-cookie'
 
 export async function POST(request: NextRequest) {
   if (!isAdmin(request)) return unauthorizedResponse()
@@ -29,13 +30,12 @@ export async function POST(request: NextRequest) {
 
   const client = clients[0]
 
-  const useSecure = new URL(request.url).protocol === 'https:'
-  const cookieName = useSecure
-    ? '__Secure-next-auth.session-token'
-    : 'next-auth.session-token'
+  const useSecure = isSecureRequest(request.url)
+  const cookieName = sessionCookieName(useSecure)
 
   const sessionToken = await encode({
-    secret: process.env.NEXTAUTH_SECRET!,
+    secret: AUTH_SECRET!,
+    salt: cookieName,
     token: {
       email: client.email as string,
       name: client.name as string,

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,3 @@
-import NextAuth from 'next-auth'
-import { authOptions } from '@/lib/auth'
+import { handlers } from '@/lib/auth'
 
-const handler = NextAuth(authOptions)
-
-export { handler as GET, handler as POST }
+export const { GET, POST } = handlers

--- a/src/app/api/auth/magic/route.ts
+++ b/src/app/api/auth/magic/route.ts
@@ -8,7 +8,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { encode } from 'next-auth/jwt'
 import { sql } from '@/lib/db'
-import { AUTH_SECRET, isSecureRequest, sessionCookieName } from '@/lib/auth-cookie'
+import { isSecureRequest, requireAuthSecret, sessionCookieName } from '@/lib/auth-cookie'
 
 export async function POST(request: NextRequest) {
   const formData = await request.formData()
@@ -52,11 +52,20 @@ export async function POST(request: NextRequest) {
   const useSecure = isSecureRequest(request.url)
   const cookieName = sessionCookieName(useSecure)
 
+  // Fail fast (controlled 500) if the signing secret is missing, rather than
+  // throwing an opaque error mid-login.
+  let secret: string
+  try {
+    secret = requireAuthSecret()
+  } catch {
+    return NextResponse.redirect(errorUrl, { status: 303 })
+  }
+
   // Create an Auth.js v5 session JWT. v5 derives the encryption key from a
   // `salt`, which defaults to the cookie name — getToken()/auth() use the same
   // derivation when reading, so the salt MUST equal the cookie name.
   const sessionToken = await encode({
-    secret: AUTH_SECRET!,
+    secret,
     salt: cookieName,
     token: {
       email: client.email as string,

--- a/src/app/api/auth/magic/route.ts
+++ b/src/app/api/auth/magic/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { encode } from 'next-auth/jwt'
 import { sql } from '@/lib/db'
+import { AUTH_SECRET, isSecureRequest, sessionCookieName } from '@/lib/auth-cookie'
 
 export async function POST(request: NextRequest) {
   const formData = await request.formData()
@@ -47,17 +48,16 @@ export async function POST(request: NextRequest) {
 
   const client = clients[0]
 
-  // Determine cookie name — NextAuth uses __Secure- prefix on HTTPS
-  const useSecure = new URL(request.url).protocol === 'https:'
-  const cookieName = useSecure
-    ? '__Secure-next-auth.session-token'
-    : 'next-auth.session-token'
+  // Auth.js v5 cookie name (__Secure- prefix on HTTPS).
+  const useSecure = isSecureRequest(request.url)
+  const cookieName = sessionCookieName(useSecure)
 
-  // Create NextAuth-compatible JWT.
-  // NextAuth internally calls decode({ ...jwtOptions, token }) where jwtOptions
-  // has no `salt` field, so the effective salt is "" — we must match that.
+  // Create an Auth.js v5 session JWT. v5 derives the encryption key from a
+  // `salt`, which defaults to the cookie name — getToken()/auth() use the same
+  // derivation when reading, so the salt MUST equal the cookie name.
   const sessionToken = await encode({
-    secret: process.env.NEXTAUTH_SECRET!,
+    secret: AUTH_SECRET!,
+    salt: cookieName,
     token: {
       email: client.email as string,
       name: client.name as string,

--- a/src/app/api/client/documents/[id]/route.ts
+++ b/src/app/api/client/documents/[id]/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { sql } from '@/lib/db'
+import { AUTH_SECRET, isSecureRequest } from '@/lib/auth-cookie'
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET })
+  const token = await getToken({
+    req: request,
+    secret: AUTH_SECRET,
+    secureCookie: isSecureRequest(request.url),
+  })
   const clientId = token?.clientId as string | undefined
 
   if (!clientId) {

--- a/src/app/api/client/documents/route.ts
+++ b/src/app/api/client/documents/route.ts
@@ -1,9 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { sql } from '@/lib/db'
+import { AUTH_SECRET, isSecureRequest } from '@/lib/auth-cookie'
 
 export async function GET(request: NextRequest) {
-  const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET })
+  const token = await getToken({
+    req: request,
+    secret: AUTH_SECRET,
+    secureCookie: isSecureRequest(request.url),
+  })
   const clientId = token?.clientId as string | undefined
 
   if (!clientId) {

--- a/src/app/api/client/invoices/route.ts
+++ b/src/app/api/client/invoices/route.ts
@@ -2,9 +2,14 @@ import { NextResponse } from 'next/server'
 import { sql } from '@/lib/db'
 import { getToken } from 'next-auth/jwt'
 import { NextRequest } from 'next/server'
+import { AUTH_SECRET, isSecureRequest } from '@/lib/auth-cookie'
 
 export async function GET(req: NextRequest) {
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+  const token = await getToken({
+    req,
+    secret: AUTH_SECRET,
+    secureCookie: isSecureRequest(req.url),
+  })
   if (!token?.email) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const rows = await sql`

--- a/src/app/api/client/projects/route.ts
+++ b/src/app/api/client/projects/route.ts
@@ -1,9 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getToken } from 'next-auth/jwt'
 import { sql } from '@/lib/db'
+import { AUTH_SECRET, isSecureRequest } from '@/lib/auth-cookie'
 
 export async function GET(request: NextRequest) {
-  const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET })
+  const token = await getToken({
+    req: request,
+    secret: AUTH_SECRET,
+    secureCookie: isSecureRequest(request.url),
+  })
   const clientId = token?.clientId as string | undefined
 
   if (!clientId) {

--- a/src/lib/auth-cookie.ts
+++ b/src/lib/auth-cookie.ts
@@ -1,0 +1,27 @@
+/**
+ * Auth.js v5 cookie naming + secret helpers.
+ *
+ * v5 renamed the session cookie from `next-auth.session-token` to
+ * `authjs.session-token` (`__Secure-` prefixed over HTTPS) and now derives the
+ * JWT encryption key from a `salt` that defaults to the cookie name. The manual
+ * `encode()` sites (magic-link login, admin impersonation) and the `getToken()`
+ * readers MUST agree on both the cookie name and the salt, so that derivation
+ * lives here in one place.
+ */
+
+/** True when the incoming request is served over HTTPS (production). */
+export function isSecureRequest(requestUrl: string): boolean {
+  return new URL(requestUrl).protocol === 'https:'
+}
+
+/** Auth.js v5 session cookie name for the given transport security. */
+export function sessionCookieName(secure: boolean): string {
+  return secure ? '__Secure-authjs.session-token' : 'authjs.session-token'
+}
+
+/**
+ * Shared secret for JWT encode/decode. v5's convention is `AUTH_SECRET`; we keep
+ * reading the existing `NEXTAUTH_SECRET` (falling back to `AUTH_SECRET`) so no
+ * Vercel env rename is required during the migration.
+ */
+export const AUTH_SECRET = process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET

--- a/src/lib/auth-cookie.ts
+++ b/src/lib/auth-cookie.ts
@@ -23,5 +23,21 @@ export function sessionCookieName(secure: boolean): string {
  * Shared secret for JWT encode/decode. v5's convention is `AUTH_SECRET`; we keep
  * reading the existing `NEXTAUTH_SECRET` (falling back to `AUTH_SECRET`) so no
  * Vercel env rename is required during the migration.
+ *
+ * May be `undefined` at build time (page-data collection runs without runtime
+ * secrets). Read paths (`getToken`) treat that as "no session"; mint paths must
+ * use {@link requireAuthSecret} to fail fast with a clear message.
  */
 export const AUTH_SECRET = process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET
+
+/**
+ * Returns the auth secret or throws a descriptive error. Use this on the
+ * session-minting paths (magic-link login, admin impersonation) so a missing
+ * env var surfaces as a controlled failure instead of an opaque crash.
+ */
+export function requireAuthSecret(): string {
+  if (!AUTH_SECRET) {
+    throw new Error('NEXTAUTH_SECRET (or AUTH_SECRET) is not set; cannot mint a session token.')
+  }
+  return AUTH_SECRET
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import NextAuth, { type NextAuthConfig } from 'next-auth'
 import { NeonAdapter } from './auth-adapter'
+import { AUTH_SECRET } from './auth-cookie'
 
 /**
  * Auth.js (next-auth v5) configuration.
@@ -12,7 +13,9 @@ import { NeonAdapter } from './auth-adapter'
 export const authConfig: NextAuthConfig = {
   adapter: NeonAdapter(),
   session: { strategy: 'jwt' },
-  secret: process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET,
+  // If unset, Auth.js throws a clear MissingSecretError on the first request;
+  // we don't throw at import so build-time page-data collection still runs.
+  secret: AUTH_SECRET,
   trustHost: true,
   pages: {
     signIn: '/client/login',

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,9 +1,19 @@
-import type { NextAuthOptions } from 'next-auth'
+import NextAuth, { type NextAuthConfig } from 'next-auth'
 import { NeonAdapter } from './auth-adapter'
 
-export const authOptions: NextAuthOptions = {
+/**
+ * Auth.js (next-auth v5) configuration.
+ *
+ * The portal uses a custom magic-link flow (no built-in providers): tokens are
+ * minted directly in /api/auth/magic via `encode()`. NextAuth here mainly powers
+ * the session endpoint (`useSession`) and sign-out. `secret` is pinned to the
+ * existing NEXTAUTH_SECRET and `trustHost` is enabled for Vercel.
+ */
+export const authConfig: NextAuthConfig = {
   adapter: NeonAdapter(),
   session: { strategy: 'jwt' },
+  secret: process.env.NEXTAUTH_SECRET ?? process.env.AUTH_SECRET,
+  trustHost: true,
   pages: {
     signIn: '/client/login',
     error: '/client/login?error=1',
@@ -28,3 +38,5 @@ export const authOptions: NextAuthOptions = {
     },
   },
 }
+
+export const { handlers, auth, signIn, signOut } = NextAuth(authConfig)

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -7,3 +7,9 @@ declare module 'next-auth' {
     } & DefaultSession['user']
   }
 }
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    clientId?: string
+  }
+}


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE.** This migration changes the client-portal session cookie name, JWT salt derivation, and token APIs. The magic-link login round-trip **cannot be exercised from CI / a non-interactive shell** — it needs a live email → confirm → session check. Merge only after completing the **Manual verification checklist** below against the Vercel **preview** deployment.

## Summary

Migrates the client-portal magic-link auth from **next-auth v4** → **v5 (Auth.js, `5.0.0-beta.31`)** and clears all 3 moderate `uuid` advisories.

## What changed

### Config / handler shape
- **`src/lib/auth.ts`** — v4 `authOptions: NextAuthOptions` + `NextAuth(authOptions)` → v5 `authConfig: NextAuthConfig` exporting `{ handlers, auth, signIn, signOut }`. `secret` is pinned to the existing `NEXTAUTH_SECRET` (fallback `AUTH_SECRET`) and `trustHost: true` is set (Vercel). Callbacks (`jwt`/`session`/`redirect`) are unchanged in behaviour.
- **`src/app/api/auth/[...nextauth]/route.ts`** — `const handler = NextAuth(...)` → `export const { GET, POST } = handlers`.

### Cookie names (BREAKING for existing sessions)
- v4 `next-auth.session-token` / `__Secure-next-auth.session-token` → **v5 `authjs.session-token` / `__Secure-authjs.session-token`**.
- Existing logged-in clients will be signed out once and must request a fresh magic link (expected, one-time).

### Token APIs (encode / decode)
- **`encode()`** (in `/api/auth/magic` and `/api/admin/clients/impersonate`) now passes a **required `salt`** equal to the cookie name. v5 derives the JWT encryption key from `secret` + `salt`; the v4 code relied on an empty-string salt, which no longer exists.
- **`getToken()`** (client read routes: `projects`, `documents`, `documents/[id]`, `invoices`) now passes **`secureCookie`** explicitly. v5 `getToken` defaults `secureCookie` to `false` (and derives `cookieName`/`salt` from it), so without this it would look for the unprefixed cookie in production and fail to decode.
- New **`src/lib/auth-cookie.ts`** centralises `isSecureRequest()`, `sessionCookieName()`, and `AUTH_SECRET` so the encode and decode sides cannot drift.

### Types
- **`src/types/next-auth.d.ts`** — added `next-auth/jwt` module augmentation for `JWT.clientId`.

### Env vars
- **No new env var required.** `secret` is pinned to `NEXTAUTH_SECRET`; `NEXTAUTH_URL` is still used by the magic-link sender. (v5's native convention is `AUTH_SECRET`/`AUTH_URL`; we deliberately did *not* rename to avoid touching Vercel env during a held migration. The helper falls back to `AUTH_SECRET` if present.)

### Adapter
- `src/lib/auth-adapter.ts` (`NeonAdapter`) is unchanged and typechecks cleanly against the v5 `Adapter` type (re-exported from `@auth/core/adapters`).

## npm audit — before / after

| | Vulnerabilities |
|---|---|
| **Before** (v4) | **3 moderate** — `uuid` <11.1.1 via both `next-auth` and `exceljs` |
| After v5 migration | 2 moderate — next-auth's `uuid` path removed; `exceljs → uuid@8` remains |
| After `uuid` override | **0** |

The v5 migration alone clears next-auth's transitive `uuid` (3 → 2). The remaining 2 came from `exceljs@4.4.0 → uuid@8.3.2`, which is **independent of auth**. Since `exceljs` only imports the named `v4` export (`const {v4} = require('uuid')`, API-compatible with uuid v11), a `"uuid": "^11.1.1"` override bumps it to the patched line → **0 vulnerabilities**.

## Automated verification (CI-runnable)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` (Vitest) — **168 passing**
- [x] `npm run test:cucumber` — **39 scenarios / 168 steps passing**
- [x] `next build` compiles + passes its TypeScript step (local page-data collection only fails on absent runtime secrets, which CI/Vercel supply)
- [x] `npm audit` — **0 vulnerabilities**

## ⚠️ Manual verification checklist (REQUIRED before merge)

Run against the **preview deployment** for this PR:

1. **Magic link request** — go to `/client/login`, submit a known client email (e.g. `finny.koshy1@gmail.com`); confirm the email arrives.
2. **Confirm page** — open the link → lands on `/client/confirm`; click **Access my portal**.
3. **Session established** — you are redirected to `/client/dashboard` and it loads projects/documents/invoices (these hit the `getToken()` read routes — proves encode salt == decode salt).
4. **Cookie name** — in DevTools → Application → Cookies, confirm the session cookie is **`__Secure-authjs.session-token`** (HTTPS preview) and `HttpOnly` + `Secure`.
5. **Protected API** — hit `/api/client/projects` while logged in (200 with data) and after sign-out / in a fresh incognito window (401).
6. **Sign-out** — click **Log out**; confirm the cookie is cleared and `/client/dashboard` redirects back to `/client/login`.
7. **Admin impersonation** — from `/admin/clients`, impersonate a client; confirm it opens that client's portal (short-lived 1h session, same v5 cookie).
8. **Admin auth unaffected** — confirm `/admin/*` still gates on the `av-admin-session` HMAC cookie (this PR does not touch admin auth / `proxy.ts`).

If all 8 pass, this PR is safe to squash-merge.

Made with [Cursor](https://cursor.com)