### PR TITLE
fix(security): sanitize admin doc preview, constant-time admin login, drop dead site-lock var

### DIFF
--- a/src/app/admin/documents/page.tsx
+++ b/src/app/admin/documents/page.tsx
@@ -353,15 +353,18 @@ function MarkdownPreview({ content }: { content: string }) {
 
   useEffect(() => {
     let cancelled = false
-    Promise.all([import('marked'), import('isomorphic-dompurify')]).then(
-      ([{ marked }, { default: DOMPurify }]) => {
+    Promise.all([import('marked'), import('isomorphic-dompurify')])
+      .then(([{ marked }, { default: DOMPurify }]) => {
         if (cancelled) return
         // marked v17 emits raw HTML (it does not sanitize); sanitize before it
         // reaches dangerouslySetInnerHTML to prevent stored XSS from document
         // content (e.g. <script>, <img onerror>).
         setHtml(DOMPurify.sanitize(marked(content) as string))
-      },
-    )
+      })
+      .catch(() => {
+        // Fail closed: render nothing rather than leaving stale/raw HTML.
+        if (!cancelled) setHtml('')
+      })
     return () => {
       cancelled = true
     }

--- a/src/app/admin/documents/page.tsx
+++ b/src/app/admin/documents/page.tsx
@@ -352,9 +352,19 @@ function MarkdownPreview({ content }: { content: string }) {
   const [html, setHtml] = useState('')
 
   useEffect(() => {
-    import('marked').then(({ marked }) => {
-      setHtml(marked(content) as string)
-    })
+    let cancelled = false
+    Promise.all([import('marked'), import('isomorphic-dompurify')]).then(
+      ([{ marked }, { default: DOMPurify }]) => {
+        if (cancelled) return
+        // marked v17 emits raw HTML (it does not sanitize); sanitize before it
+        // reaches dangerouslySetInnerHTML to prevent stored XSS from document
+        // content (e.g. <script>, <img onerror>).
+        setHtml(DOMPurify.sanitize(marked(content) as string))
+      },
+    )
+    return () => {
+      cancelled = true
+    }
   }, [content])
 
   return (

--- a/src/app/api/admin/auth/route.ts
+++ b/src/app/api/admin/auth/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { ADMIN_COOKIE, getAdminSessionToken } from '@/lib/admin-auth'
+import { ADMIN_COOKIE, getAdminSessionToken, safeEqual } from '@/lib/admin-auth'
 
 export async function POST(request: NextRequest) {
   const { passphrase, next, rememberMe } = await request.json()
 
-  if (!passphrase || passphrase !== process.env.ADMIN_PASSPHRASE) {
+  // Constant-time comparison avoids a timing oracle on the passphrase.
+  if (!safeEqual(passphrase, process.env.ADMIN_PASSPHRASE)) {
     return NextResponse.json({ error: 'Incorrect passphrase' }, { status: 401 })
   }
 

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -20,6 +20,20 @@ export function getAdminSessionToken(): string | null {
 }
 
 /**
+ * Constant-time string comparison. Returns false on length mismatch (which is
+ * not itself secret) without leaking byte-by-byte timing for equal-length
+ * inputs. Use for any secret comparison (session cookie, passphrase).
+ */
+export function safeEqual(a: string | undefined | null, b: string | undefined | null): boolean {
+  if (!a || !b) return false
+  const aBuf = Buffer.from(a)
+  const bBuf = Buffer.from(b)
+  // Lengths must match first to avoid timingSafeEqual throwing on mismatch
+  if (aBuf.length !== bBuf.length) return false
+  return timingSafeEqual(aBuf, bBuf)
+}
+
+/**
  * Returns true if the request carries a valid admin session cookie.
  * The cookie is set by POST /api/admin/auth after passphrase verification.
  *
@@ -28,12 +42,7 @@ export function getAdminSessionToken(): string | null {
 export function isAdmin(request: NextRequest): boolean {
   const cookieValue = request.cookies.get(ADMIN_COOKIE)?.value
   const expected = getAdminSessionToken()
-  if (!cookieValue || !expected) return false
-  const a = Buffer.from(cookieValue)
-  const b = Buffer.from(expected)
-  // Lengths must match first to avoid timingSafeEqual throwing on mismatch
-  if (a.length !== b.length) return false
-  return timingSafeEqual(a, b)
+  return safeEqual(cookieValue, expected)
 }
 
 /** Standard 401 response for unauthenticated admin requests. */

--- a/src/lib/admin-auth.ts
+++ b/src/lib/admin-auth.ts
@@ -24,8 +24,10 @@ export function getAdminSessionToken(): string | null {
  * not itself secret) without leaking byte-by-byte timing for equal-length
  * inputs. Use for any secret comparison (session cookie, passphrase).
  */
-export function safeEqual(a: string | undefined | null, b: string | undefined | null): boolean {
-  if (!a || !b) return false
+export function safeEqual(a: unknown, b: unknown): boolean {
+  // Fail closed on missing or non-string input (e.g. a JSON body field that is
+  // an object/number) rather than letting Buffer.from throw a 500.
+  if (typeof a !== 'string' || typeof b !== 'string' || !a || !b) return false
   const aBuf = Buffer.from(a)
   const bBuf = Buffer.from(b)
   // Lengths must match first to avoid timingSafeEqual throwing on mismatch

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -47,8 +47,6 @@ function buildCsp(nonce: string): string {
   ].join('; ')
 }
 
-const PREVIEW_PASSWORD = process.env.PREVIEW_PASSWORD
-
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
 
@@ -70,15 +68,6 @@ export async function proxy(request: NextRequest) {
   // Cron routes enforce their own auth (e.g. CRON_SECRET) at the handler level.
   if (pathname.startsWith('/api/cron/')) {
     return NextResponse.next()
-  }
-
-  // Client portal and auth API routes must be reachable without the site lock
-  // so magic-link invites work for clients who don't have the preview password
-  if (
-    pathname.startsWith('/client/') ||
-    pathname.startsWith('/api/auth/')
-  ) {
-    // Skip basic-auth — fall through to normal security headers below
   }
 
   // Generate nonce for CSP and security

--- a/tests/unit/markdown-sanitize.test.ts
+++ b/tests/unit/markdown-sanitize.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { marked } from "marked";
+import DOMPurify from "isomorphic-dompurify";
+
+/**
+ * Guards the #8 fix: the admin document preview renders `marked()` output via
+ * dangerouslySetInnerHTML. marked v17 does NOT sanitize, so the component runs
+ * the output through DOMPurify first. These tests assert that pipeline strips
+ * active content while preserving benign formatting.
+ */
+function renderSafe(md: string): string {
+  return DOMPurify.sanitize(marked(md) as string);
+}
+
+describe("admin document markdown sanitization", () => {
+  it("strips <script> tags from document content", () => {
+    const html = renderSafe('# Title\n\n<script>alert("xss")</script>');
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("alert(");
+  });
+
+  it("strips event-handler attributes like img onerror", () => {
+    const html = renderSafe('<img src="x" onerror="alert(1)">');
+    expect(html).not.toContain("onerror");
+  });
+
+  it("preserves benign markdown formatting", () => {
+    const html = renderSafe("# Heading\n\n**bold** and a [link](https://example.com)");
+    expect(html).toContain("<h1");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain('href="https://example.com"');
+  });
+});

--- a/tests/unit/markdown-sanitize.test.ts
+++ b/tests/unit/markdown-sanitize.test.ts
@@ -3,10 +3,11 @@ import { marked } from "marked";
 import DOMPurify from "isomorphic-dompurify";
 
 /**
- * Guards the #8 fix: the admin document preview renders `marked()` output via
- * dangerouslySetInnerHTML. marked v17 does NOT sanitize, so the component runs
- * the output through DOMPurify first. These tests assert that pipeline strips
- * active content while preserving benign formatting.
+ * Covers the sanitization pipeline used by the #8 fix in the admin document
+ * preview: `marked()` produces unsanitized HTML, which the component runs
+ * through `DOMPurify.sanitize()` before `dangerouslySetInnerHTML`. These tests
+ * exercise that marked → DOMPurify pipeline directly (not the React component)
+ * to assert it strips active content while preserving benign formatting.
  */
 function renderSafe(md: string): string {
   return DOMPurify.sanitize(marked(md) as string);


### PR DESCRIPTION
## Summary

Focused security-hardening pass grouping three small, isolated fixes from the backlog.

### #8 — Stored XSS in admin document preview (P2)
`MarkdownPreview` in `src/app/admin/documents/page.tsx` rendered `marked()` output via `dangerouslySetInnerHTML`. `marked` v17 does **not** sanitize, so any HTML in document content (e.g. `<script>`, `<img onerror>`) executed in the admin's session. Output is now run through `isomorphic-dompurify` (`DOMPurify.sanitize(...)`) before injection — the same library/pattern already used in `src/app/api/admin/documents/[id]/pdf/route.ts`.

### #13 — Timing oracle on admin login (P3)
`src/app/api/admin/auth/route.ts` compared the submitted passphrase with `!==`, which short-circuits and leaks timing. Replaced with a new reusable `safeEqual()` helper in `src/lib/admin-auth.ts` backed by `crypto.timingSafeEqual` (returns `false` on length mismatch without throwing). `isAdmin()` now reuses the same helper.

### #5 / #14 — Dead site-lock remnants
Removed the unused `PREVIEW_PASSWORD` constant and the no-op `if (/client/ || /api/auth/) {}` block in `src/proxy.ts` left behind after the basic-auth preview lock was removed. Confirmed no `PREVIEW_PASSWORD` references remain in `src/`. (Functional webhook/cron early-returns were left intact — they skip rate-limiting, not the removed lock.)

## Tests
- New `tests/unit/markdown-sanitize.test.ts` asserts the marked→DOMPurify pipeline strips `<script>` and `onerror` while preserving benign markdown.
- `npm test`: **171 passing** (18 files).
- `tsc --noEmit`: clean. `npm run lint`: 0 errors. `next build`: compiles + TypeScript pass (local page-data collection needs runtime secrets, provided by CI/Vercel).

## Verification
No env or behavioral changes for end users; admin auth and document rendering behavior is unchanged for valid input.

Fixes #8
Fixes #13
Fixes #5
Fixes #14

Made with [Cursor](https://cursor.com)