### PR TITLE
fix(auth): store magic-link tokens as SHA-256 hash at rest

### DIFF
--- a/src/app/api/auth/magic/route.ts
+++ b/src/app/api/auth/magic/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { encode } from 'next-auth/jwt'
 import { sql } from '@/lib/db'
 import { isSecureRequest, requireAuthSecret, sessionCookieName } from '@/lib/auth-cookie'
+import { hashMagicLinkToken } from '@/lib/magic-link-token'
 
 export async function POST(request: NextRequest) {
   const formData = await request.formData()
@@ -22,11 +23,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.redirect(errorUrl, { status: 303 })
   }
 
-  // Verify and consume the token atomically
+  // Tokens are stored as a SHA-256 hash; hash the presented token and match on
+  // the hash. Verify and consume the token atomically.
+  const tokenHash = hashMagicLinkToken(token)
   const rows = await sql`
     DELETE FROM verification_tokens
     WHERE identifier = ${email}
-      AND token = ${token}
+      AND token = ${tokenHash}
       AND expires > NOW()
     RETURNING identifier
   `

--- a/src/lib/magic-link-token.ts
+++ b/src/lib/magic-link-token.ts
@@ -1,0 +1,18 @@
+import crypto from 'crypto'
+
+/**
+ * Magic-link tokens are high-entropy random strings (256 bits) sent to the user
+ * by email. We store only their SHA-256 hash in `verification_tokens.token` so
+ * that a read of the database (leak, backup, log) does not expose live login
+ * tokens — an attacker would still need the original token from the email.
+ *
+ * Because the token is full-entropy and random, a plain (unsalted) SHA-256 is
+ * sufficient: there is nothing to brute-force or rainbow-table. The hash is
+ * deterministic, so verification re-hashes the presented token and compares.
+ *
+ * The hex digest is 64 chars — the same width as the previous plaintext token —
+ * so no schema change is required.
+ */
+export function hashMagicLinkToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex')
+}

--- a/src/lib/send-magic-link.ts
+++ b/src/lib/send-magic-link.ts
@@ -5,12 +5,16 @@
 import { Resend } from 'resend'
 import crypto from 'crypto'
 import { sql } from './db'
+import { hashMagicLinkToken } from './magic-link-token'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
 export async function sendMagicLink(email: string): Promise<void> {
   const baseUrl = process.env.NEXTAUTH_URL ?? 'https://aetherisvision.com'
+  // The plaintext token travels only in the email link; only its hash is
+  // persisted, so a DB read cannot recover a usable login token.
   const token = crypto.randomBytes(32).toString('hex')
+  const tokenHash = hashMagicLinkToken(token)
   const expires = new Date(Date.now() + 24 * 60 * 60 * 1000) // 24 hours
 
   // One active token per email at a time
@@ -18,7 +22,7 @@ export async function sendMagicLink(email: string): Promise<void> {
 
   await sql`
     INSERT INTO verification_tokens (identifier, token, expires)
-    VALUES (${email}, ${token}, ${expires})
+    VALUES (${email}, ${tokenHash}, ${expires})
   `
 
   const confirmUrl = `${baseUrl}/client/confirm?token=${token}&email=${encodeURIComponent(email)}`

--- a/tests/unit/magic-link-token.test.ts
+++ b/tests/unit/magic-link-token.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import crypto from "crypto";
+import { hashMagicLinkToken } from "@/lib/magic-link-token";
+
+/**
+ * Guards #9: magic-link tokens are stored only as a SHA-256 hash. The mint path
+ * (send-magic-link.ts) and the verify path (/api/auth/magic) both run the token
+ * through this helper, so its determinism is what makes a login succeed while a
+ * DB read of the stored hash stays useless to an attacker.
+ */
+describe("hashMagicLinkToken", () => {
+  it("is deterministic for the same token (mint hash === verify hash)", () => {
+    const token = crypto.randomBytes(32).toString("hex");
+    expect(hashMagicLinkToken(token)).toBe(hashMagicLinkToken(token));
+  });
+
+  it("produces a 64-char hex SHA-256 digest", () => {
+    const hash = hashMagicLinkToken("any-token");
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("matches a known SHA-256 vector", () => {
+    // sha256("abc")
+    expect(hashMagicLinkToken("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+
+  it("does not return the plaintext token, and differs for different tokens", () => {
+    const a = crypto.randomBytes(32).toString("hex");
+    const b = crypto.randomBytes(32).toString("hex");
+    expect(hashMagicLinkToken(a)).not.toBe(a);
+    expect(hashMagicLinkToken(a)).not.toBe(hashMagicLinkToken(b));
+  });
+});

--- a/tests/unit/magic-link-token.test.ts
+++ b/tests/unit/magic-link-token.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from "vitest";
-import crypto from "crypto";
 import { hashMagicLinkToken } from "@/lib/magic-link-token";
 
 /**
@@ -10,7 +9,7 @@ import { hashMagicLinkToken } from "@/lib/magic-link-token";
  */
 describe("hashMagicLinkToken", () => {
   it("is deterministic for the same token (mint hash === verify hash)", () => {
-    const token = crypto.randomBytes(32).toString("hex");
+    const token = "fixed-token-deadbeefdeadbeefdeadbeefdeadbeef";
     expect(hashMagicLinkToken(token)).toBe(hashMagicLinkToken(token));
   });
 
@@ -27,8 +26,8 @@ describe("hashMagicLinkToken", () => {
   });
 
   it("does not return the plaintext token, and differs for different tokens", () => {
-    const a = crypto.randomBytes(32).toString("hex");
-    const b = crypto.randomBytes(32).toString("hex");
+    const a = "token-aaaa1111aaaa1111aaaa1111aaaa1111";
+    const b = "token-bbbb2222bbbb2222bbbb2222bbbb2222";
     expect(hashMagicLinkToken(a)).not.toBe(a);
     expect(hashMagicLinkToken(a)).not.toBe(hashMagicLinkToken(b));
   });


### PR DESCRIPTION
## Summary
Magic-link login tokens were stored in `verification_tokens.token` in **plaintext**, so any read of the database (leak, backup, replicated log) exposed live, usable login tokens. This stores only a SHA-256 hash at rest.

## Changes
- **`src/lib/magic-link-token.ts`** (new): `hashMagicLinkToken(token)` — SHA-256 hex digest. The token is full-entropy (256-bit random), so an unsalted SHA-256 is sufficient (nothing to brute-force/rainbow-table). The digest is 64 chars — same width as the old plaintext token, so **no schema change** is needed.
- **`src/lib/send-magic-link.ts`** (mint): stores `hashMagicLinkToken(token)`; the plaintext token travels only in the emailed link.
- **`src/app/api/auth/magic/route.ts`** (verify): hashes the presented token and matches on the hash. The atomic `DELETE … RETURNING` consume semantics are unchanged.
- Unit tests in `tests/unit/magic-link-token.test.ts` (determinism = mint hash equals verify hash, hex digest shape, known `sha256("abc")` vector, non-plaintext / collision-free).

## Scope note
The NextAuth adapter's `createVerificationToken` / `useVerificationToken` (`src/lib/auth-adapter.ts`) are **not** part of the live flow — `src/lib/auth.ts` configures `providers: []`, so NextAuth never invokes them. The custom `sendMagicLink` → `/api/auth/magic` path is the only mint/verify path and is fully covered here. Left untouched to keep the change tight.

## Verification
- `tsc --noEmit` clean; `npm run lint` 0 errors; `npm test` **175 passing** (19 files).
- No env or schema changes. Existing tokens (plaintext) in the DB will simply fail to verify after deploy and users re-request a link; one active token per email is already enforced.

Fixes #9

Made with [Cursor](https://cursor.com)