### PR TITLE
feat(security): distributed rate limiting via Upstash Redis (Vercel KV)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@react-three/fiber": "^9.5.0",
         "@types/dompurify": "^3.0.5",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.0",
         "@vercel/analytics": "^1.6.1",
         "@vercel/blob": "^2.3.2",
         "clsx": "^2.1.1",
@@ -4223,6 +4225,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@use-gesture/core": {
       "version": "10.3.1",
@@ -13588,6 +13623,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.25.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "@react-three/fiber": "^9.5.0",
     "@types/dompurify": "^3.0.5",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "@vercel/analytics": "^1.6.1",
     "@vercel/blob": "^2.3.2",
     "clsx": "^2.1.1",

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,52 +1,17 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { CHAT_SYSTEM_PROMPT } from "@/lib/chat-context";
+import { rateLimit } from "@/lib/rate-limit";
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 export const runtime = "nodejs";
 
-// ---------------------------------------------------------------------------
-// In-memory rate limiter
-// Limits: 20 requests per IP per 15-minute window
-// ---------------------------------------------------------------------------
+// Rate limit: 10 requests per IP per 15-minute window. Distributed across
+// Vercel instances when Upstash/Vercel KV is configured, else in-memory
+// fallback (issue #12).
 const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 const MAX_REQUESTS = 10;
 const MAX_TURNS = 10; // max conversation turns per session
-
-interface RateLimitEntry {
-  count: number;
-  windowStart: number;
-}
-
-const rateLimitMap = new Map<string, RateLimitEntry>();
-
-// Purge stale entries every 15 minutes to prevent memory growth
-setInterval(() => {
-  const now = Date.now();
-  for (const [ip, entry] of rateLimitMap.entries()) {
-    if (now - entry.windowStart > WINDOW_MS) {
-      rateLimitMap.delete(ip);
-    }
-  }
-}, WINDOW_MS);
-
-function checkRateLimit(ip: string): { allowed: boolean; retryAfter: number } {
-  const now = Date.now();
-  const entry = rateLimitMap.get(ip);
-
-  if (!entry || now - entry.windowStart > WINDOW_MS) {
-    rateLimitMap.set(ip, { count: 1, windowStart: now });
-    return { allowed: true, retryAfter: 0 };
-  }
-
-  if (entry.count >= MAX_REQUESTS) {
-    const retryAfter = Math.ceil((WINDOW_MS - (now - entry.windowStart)) / 1000);
-    return { allowed: false, retryAfter };
-  }
-
-  entry.count += 1;
-  return { allowed: true, retryAfter: 0 };
-}
 
 function getClientIp(request: Request): string {
   const forwarded = request.headers.get("x-forwarded-for");
@@ -60,13 +25,17 @@ function getClientIp(request: Request): string {
 export async function POST(request: Request) {
   // Rate limit check
   const ip = getClientIp(request);
-  const { allowed, retryAfter } = checkRateLimit(ip);
+  const { success, retryAfterSeconds } = await rateLimit(ip, {
+    limit: MAX_REQUESTS,
+    windowMs: WINDOW_MS,
+    prefix: "chat",
+  });
 
-  if (!allowed) {
+  if (!success) {
     return new Response("Too many requests. Please try again later.", {
       status: 429,
       headers: {
-        "Retry-After": String(retryAfter),
+        "Retry-After": String(retryAfterSeconds),
         "Content-Type": "text/plain",
       },
     });

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,36 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 import { SITE } from "@/lib/constants";
+import { rateLimit } from "@/lib/rate-limit";
 
-// ---------------------------------------------------------------------------
-// In-memory rate limiter
-// Serverless note: state resets on cold starts, but works well for a low-
-// traffic site. Limit: 5 submissions per IP per 10 minutes.
-// ---------------------------------------------------------------------------
+// Rate limit: 5 submissions per IP per 10 minutes. Distributed across Vercel
+// instances when Upstash/Vercel KV is configured, else in-memory (issue #12).
 const RATE_LIMIT = 5;
 const WINDOW_MS = 10 * 60 * 1000; // 10 minutes
-const ipMap = new Map<string, { count: number; resetAt: number }>();
-
-function isRateLimited(ip: string): boolean {
-  const now = Date.now();
-  const entry = ipMap.get(ip);
-
-  if (!entry || now > entry.resetAt) {
-    ipMap.set(ip, { count: 1, resetAt: now + WINDOW_MS });
-    return false;
-  }
-
-  if (entry.count >= RATE_LIMIT) return true;
-
-  entry.count++;
-  return false;
-}
 
 export async function POST(req: NextRequest) {
   // ── Rate limiting ──────────────────────────────────────────────────────────
   const ip =
     req.headers.get("x-forwarded-for")?.split(",")[0].trim() ?? "unknown";
 
-  if (isRateLimited(ip)) {
+  const { success } = await rateLimit(ip, {
+    limit: RATE_LIMIT,
+    windowMs: WINDOW_MS,
+    prefix: "contact",
+  });
+  if (!success) {
     return NextResponse.json(
       { error: "Too many requests. Please wait before trying again." },
       { status: 429 }

--- a/src/app/api/intake/route.ts
+++ b/src/app/api/intake/route.ts
@@ -2,23 +2,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Resend } from 'resend';
 import { generateComplianceScoping, REGULATED_FRAMEWORKS } from '@/lib/compliance-agent';
 import { sql } from '@/lib/db';
+import { rateLimit } from '@/lib/rate-limit';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
-// Simple in-memory rate limit: max 5 submissions per IP per 10 minutes
-const rateLimitMap = new Map<string, { count: number; reset: number }>();
-
-function isRateLimited(ip: string): boolean {
-  const now = Date.now();
-  const entry = rateLimitMap.get(ip);
-  if (!entry || entry.reset < now) {
-    rateLimitMap.set(ip, { count: 1, reset: now + 10 * 60 * 1000 });
-    return false;
-  }
-  if (entry.count >= 5) return true;
-  entry.count++;
-  return false;
-}
+// Rate limit: 5 submissions per IP per 10 minutes. Distributed across Vercel
+// instances when Upstash/Vercel KV is configured, else in-memory (issue #12).
+const RATE_LIMIT = 5;
+const WINDOW_MS = 10 * 60 * 1000;
 
 interface IntakeFormData {
   companyName: string;
@@ -132,7 +123,12 @@ export async function POST(request: NextRequest) {
               ?? request.headers.get('x-real-ip')
               ?? 'unknown';
 
-    if (isRateLimited(ip)) {
+    const { success } = await rateLimit(ip, {
+      limit: RATE_LIMIT,
+      windowMs: WINDOW_MS,
+      prefix: 'intake',
+    });
+    if (!success) {
       return NextResponse.json(
         { error: 'Too many submissions. Please wait before trying again.' },
         { status: 429 }

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -1,23 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { Resend } from 'resend'
 import { createReview, getApprovedReviews, ensureReviewsTable } from '@/lib/db/reviews'
+import { rateLimit } from '@/lib/rate-limit'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
-// In-memory rate limit: 3 submissions per IP per 10 minutes
-const rateLimitMap = new Map<string, { count: number; reset: number }>()
-
-function isRateLimited(ip: string): boolean {
-  const now = Date.now()
-  const entry = rateLimitMap.get(ip)
-  if (!entry || entry.reset < now) {
-    rateLimitMap.set(ip, { count: 1, reset: now + 10 * 60 * 1000 })
-    return false
-  }
-  if (entry.count >= 3) return true
-  entry.count++
-  return false
-}
+// Rate limit: 3 submissions per IP per 10 minutes. Distributed across Vercel
+// instances when Upstash/Vercel KV is configured, else in-memory (issue #12).
+const RATE_LIMIT = 3
+const WINDOW_MS = 10 * 60 * 1000
 
 export async function GET() {
   try {
@@ -36,7 +27,12 @@ export async function POST(req: NextRequest) {
     req.headers.get('x-real-ip') ??
     'unknown'
 
-  if (isRateLimited(ip)) {
+  const { success } = await rateLimit(ip, {
+    limit: RATE_LIMIT,
+    windowMs: WINDOW_MS,
+    prefix: 'reviews',
+  })
+  if (!success) {
     return NextResponse.json(
       { error: 'Too many submissions. Please wait before trying again.' },
       { status: 429 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,139 @@
+import { Ratelimit, type Duration } from '@upstash/ratelimit'
+import { Redis } from '@upstash/redis'
+
+/**
+ * Shared rate limiter.
+ *
+ * Issue #12: per-instance `new Map()` limiters are ineffective on Vercel —
+ * each serverless/edge instance has its own memory, so an attacker spread
+ * across instances bypasses the limit and counters reset on cold start.
+ *
+ * When the Upstash Redis env vars are present (provisioned via the Vercel
+ * Marketplace — "Vercel KV" is Upstash Redis under the hood) this uses a
+ * distributed fixed-window limiter shared across all instances. When they are
+ * absent (local dev / CI) it falls back to the previous in-memory limiter so
+ * the app still runs without external infrastructure.
+ *
+ * Works in both the Edge runtime (proxy.ts) and the Node.js runtime (API
+ * routes): the Upstash client is REST/fetch-based.
+ */
+export interface RateLimitOptions {
+  /** Max requests allowed within the window. */
+  limit: number
+  /** Window length in milliseconds. */
+  windowMs: number
+  /** Namespace so different routes do not share counters. */
+  prefix: string
+}
+
+export interface RateLimitResult {
+  success: boolean
+  /** Requests remaining in the current window. */
+  remaining: number
+  /** Seconds until the window resets — use for the `Retry-After` header. */
+  retryAfterSeconds: number
+}
+
+/** True when the distributed (Upstash/Vercel KV) backend is configured. */
+export function isRateLimitDistributed(): boolean {
+  return Boolean(
+    process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN,
+  )
+}
+
+// ---- Distributed backend (Upstash Redis) -----------------------------------
+
+let redis: Redis | null = null
+const limiters = new Map<string, Ratelimit>()
+
+function msToDuration(windowMs: number): Duration {
+  const seconds = Math.max(1, Math.ceil(windowMs / 1000))
+  return `${seconds} s`
+}
+
+function getLimiter(opts: RateLimitOptions): Ratelimit {
+  const key = `${opts.prefix}:${opts.limit}:${opts.windowMs}`
+  let limiter = limiters.get(key)
+  if (!limiter) {
+    redis ??= Redis.fromEnv()
+    limiter = new Ratelimit({
+      redis,
+      // Fixed window matches the previous in-memory semantics.
+      limiter: Ratelimit.fixedWindow(opts.limit, msToDuration(opts.windowMs)),
+      prefix: `rl:${opts.prefix}`,
+      analytics: false,
+    })
+    limiters.set(key, limiter)
+  }
+  return limiter
+}
+
+// ---- In-memory fallback ----------------------------------------------------
+
+const memStore = new Map<string, { count: number; resetAt: number }>()
+
+function sweepExpired(now: number): void {
+  // Opportunistic cleanup to bound memory (replaces the per-route setInterval).
+  if (memStore.size < 5000) return
+  for (const [k, v] of memStore.entries()) {
+    if (now > v.resetAt) memStore.delete(k)
+  }
+}
+
+function memoryLimit(identifier: string, opts: RateLimitOptions): RateLimitResult {
+  const now = Date.now()
+  sweepExpired(now)
+  const key = `${opts.prefix}:${identifier}`
+  const entry = memStore.get(key)
+
+  if (!entry || now > entry.resetAt) {
+    memStore.set(key, { count: 1, resetAt: now + opts.windowMs })
+    return { success: true, remaining: opts.limit - 1, retryAfterSeconds: 0 }
+  }
+
+  if (entry.count >= opts.limit) {
+    return {
+      success: false,
+      remaining: 0,
+      retryAfterSeconds: Math.max(1, Math.ceil((entry.resetAt - now) / 1000)),
+    }
+  }
+
+  entry.count++
+  return { success: true, remaining: opts.limit - entry.count, retryAfterSeconds: 0 }
+}
+
+// ---- Public API ------------------------------------------------------------
+
+/**
+ * Check (and consume) one unit of rate-limit budget for `identifier` (usually
+ * the client IP). Returns whether the request is allowed plus headroom/retry
+ * info. Never throws: a distributed-backend failure degrades to the in-memory
+ * limiter so the site stays up.
+ */
+export async function rateLimit(
+  identifier: string,
+  opts: RateLimitOptions,
+): Promise<RateLimitResult> {
+  if (isRateLimitDistributed()) {
+    try {
+      const { success, remaining, reset } = await getLimiter(opts).limit(identifier)
+      return {
+        success,
+        remaining: Math.max(0, remaining),
+        retryAfterSeconds: Math.max(0, Math.ceil((reset - Date.now()) / 1000)),
+      }
+    } catch (err) {
+      // A Redis/network failure must not take the site down — fall back to the
+      // per-instance limiter for this request.
+      console.error('rate-limit: distributed backend error, using in-memory fallback', err)
+      return memoryLimit(identifier, opts)
+    }
+  }
+  return memoryLimit(identifier, opts)
+}
+
+/** Test-only: clear the in-memory store between cases. */
+export function __resetInMemoryRateLimit(): void {
+  memStore.clear()
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -72,11 +72,26 @@ function getLimiter(opts: RateLimitOptions): Ratelimit {
 
 const memStore = new Map<string, { count: number; resetAt: number }>()
 
+// Hard cap on the in-memory store so high-cardinality traffic (many unique
+// IPs) or a sustained attack during a Redis outage cannot grow it without
+// bound in a long-lived Node process.
+const MAX_MEM_ENTRIES = 10000
+
 function sweepExpired(now: number): void {
   // Opportunistic cleanup to bound memory (replaces the per-route setInterval).
-  if (memStore.size < 5000) return
+  if (memStore.size < MAX_MEM_ENTRIES) return
   for (const [k, v] of memStore.entries()) {
     if (now > v.resetAt) memStore.delete(k)
+  }
+  // If still over the cap after removing expired entries, evict oldest
+  // (insertion-order) entries until back under the limit.
+  if (memStore.size >= MAX_MEM_ENTRIES) {
+    const evict = memStore.size - MAX_MEM_ENTRIES + 1
+    let i = 0
+    for (const k of memStore.keys()) {
+      memStore.delete(k)
+      if (++i >= evict) break
+    }
   }
 }
 
@@ -118,10 +133,13 @@ export async function rateLimit(
   if (isRateLimitDistributed()) {
     try {
       const { success, remaining, reset } = await getLimiter(opts).limit(identifier)
+      const retry = Math.max(0, Math.ceil((reset - Date.now()) / 1000))
       return {
         success,
         remaining: Math.max(0, remaining),
-        retryAfterSeconds: Math.max(0, Math.ceil((reset - Date.now()) / 1000)),
+        // Guarantee a non-zero Retry-After on denial even if clock skew makes
+        // the computed value 0, so clients don't hot-loop retries.
+        retryAfterSeconds: success ? retry : Math.max(1, retry),
       }
     } catch (err) {
       // A Redis/network failure must not take the site down — fall back to the

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -80,9 +80,10 @@ export async function proxy(request: NextRequest) {
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
              request.headers.get('x-real-ip') ||
              'unknown'
+  const isApiRoute = pathname === '/api' || pathname.startsWith('/api/')
   const maxRequests = 100
   let rateRemaining = maxRequests - 1
-  if (pathname.startsWith('/api')) {
+  if (isApiRoute) {
     const result = await rateLimit(ip, {
       limit: maxRequests,
       windowMs: 15 * 60 * 1000, // 15 minutes
@@ -124,7 +125,7 @@ export async function proxy(request: NextRequest) {
   response.headers.set('X-Request-ID', crypto.randomUUID())
 
   // API routes report remaining rate-limit budget
-  if (pathname.startsWith('/api')) {
+  if (isApiRoute) {
     response.headers.set('X-Rate-Limit-Remaining', Math.max(0, rateRemaining).toString())
   }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-
-// Rate limiting store (in production, use Redis)
-const rateLimitStore = new Map<string, { count: number; resetTime: number }>()
+import { rateLimit } from '@/lib/rate-limit'
 
 /**
  * Verify the admin session cookie using Web Crypto (Edge Runtime compatible).
@@ -74,25 +72,27 @@ export async function proxy(request: NextRequest) {
   const nonce = crypto.randomUUID()
   const csp = buildCsp(nonce)
 
-  // Advanced Rate limiting demonstration
-  const ip = request.headers.get('x-forwarded-for') || 
-             request.headers.get('x-real-ip') || 
+  // Coarse per-IP rate limit. Distributed (shared across all Vercel instances)
+  // when Upstash/Vercel KV is configured, else in-memory fallback (issue #12).
+  // Scoped to /api/* so we don't pay a Redis round-trip on every page view;
+  // the abuse surface is the API, and sensitive POST routes add their own
+  // tighter per-route limits.
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
+             request.headers.get('x-real-ip') ||
              'unknown'
-  const now = Date.now()
-  const windowMs = 15 * 60 * 1000 // 15 minutes
   const maxRequests = 100
-  
-  const clientData = rateLimitStore.get(ip)
-  if (!clientData || now > clientData.resetTime) {
-    rateLimitStore.set(ip, { count: 1, resetTime: now + windowMs })
-  } else {
-    clientData.count++
-    if (clientData.count > maxRequests) {
-      return new NextResponse('Rate limit exceeded', { 
+  let rateRemaining = maxRequests - 1
+  if (pathname.startsWith('/api')) {
+    const result = await rateLimit(ip, {
+      limit: maxRequests,
+      windowMs: 15 * 60 * 1000, // 15 minutes
+      prefix: 'proxy-api',
+    })
+    rateRemaining = result.remaining
+    if (!result.success) {
+      return new NextResponse('Rate limit exceeded', {
         status: 429,
-        headers: {
-          'Retry-After': Math.ceil((clientData.resetTime - now) / 1000).toString()
-        }
+        headers: { 'Retry-After': result.retryAfterSeconds.toString() },
       })
     }
   }
@@ -125,7 +125,7 @@ export async function proxy(request: NextRequest) {
 
   // API routes report remaining rate-limit budget
   if (pathname.startsWith('/api')) {
-    response.headers.set('X-Rate-Limit-Remaining', (maxRequests - (clientData?.count || 1)).toString())
+    response.headers.set('X-Rate-Limit-Remaining', Math.max(0, rateRemaining).toString())
   }
 
   return response

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -129,6 +129,19 @@ describe("rate-limit — distributed (Upstash env present)", () => {
     expect(r.success).toBe(false);
   });
 
+  it("forces Retry-After >= 1 on denial even with clock skew (reset in past)", async () => {
+    setUpstashEnv();
+    limitMock.mockResolvedValue({
+      success: false,
+      remaining: 0,
+      reset: Date.now() - 5_000, // skew: reset already elapsed locally
+    });
+
+    const r = await rateLimit("9.9.9.9", { limit: 1, windowMs: 60_000, prefix: "skew" });
+    expect(r.success).toBe(false);
+    expect(r.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+  });
+
   it("falls back to in-memory when the distributed backend throws", async () => {
     setUpstashEnv();
     limitMock.mockRejectedValue(new Error("redis down"));

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// Hoisted mocks for the Upstash client so we can drive the distributed path
+// without a real Redis.
+const { limitMock, fromEnvMock } = vi.hoisted(() => ({
+  limitMock: vi.fn(),
+  fromEnvMock: vi.fn(() => ({})),
+}));
+
+vi.mock("@upstash/redis", () => ({
+  Redis: { fromEnv: fromEnvMock },
+}));
+
+vi.mock("@upstash/ratelimit", () => ({
+  Ratelimit: class {
+    static fixedWindow() {
+      return {};
+    }
+    limit(id: string) {
+      return limitMock(id);
+    }
+  },
+}));
+
+import {
+  rateLimit,
+  isRateLimitDistributed,
+  __resetInMemoryRateLimit,
+} from "@/lib/rate-limit";
+
+const URL_KEY = "UPSTASH_REDIS_REST_URL";
+const TOKEN_KEY = "UPSTASH_REDIS_REST_TOKEN";
+
+function clearUpstashEnv() {
+  delete process.env[URL_KEY];
+  delete process.env[TOKEN_KEY];
+}
+
+function setUpstashEnv() {
+  process.env[URL_KEY] = "https://example.upstash.io";
+  process.env[TOKEN_KEY] = "test-token";
+}
+
+beforeEach(() => {
+  __resetInMemoryRateLimit();
+  limitMock.mockReset();
+  clearUpstashEnv();
+});
+
+describe("rate-limit — in-memory fallback (no Upstash env)", () => {
+  it("reports not-distributed when env vars are absent", () => {
+    expect(isRateLimitDistributed()).toBe(false);
+  });
+
+  it("allows up to the limit, then blocks with a retry-after", async () => {
+    const opts = { limit: 2, windowMs: 60_000, prefix: "test" };
+
+    const r1 = await rateLimit("1.1.1.1", opts);
+    const r2 = await rateLimit("1.1.1.1", opts);
+    const r3 = await rateLimit("1.1.1.1", opts);
+
+    expect(r1.success).toBe(true);
+    expect(r1.remaining).toBe(1);
+    expect(r2.success).toBe(true);
+    expect(r2.remaining).toBe(0);
+    expect(r3.success).toBe(false);
+    expect(r3.retryAfterSeconds).toBeGreaterThan(0);
+    // Never touches the distributed backend.
+    expect(limitMock).not.toHaveBeenCalled();
+  });
+
+  it("tracks identifiers and prefixes independently", async () => {
+    const opts = { limit: 1, windowMs: 60_000, prefix: "a" };
+    expect((await rateLimit("ip-a", opts)).success).toBe(true);
+    expect((await rateLimit("ip-a", opts)).success).toBe(false);
+    // Different IP — fresh budget.
+    expect((await rateLimit("ip-b", opts)).success).toBe(true);
+    // Same IP, different route prefix — fresh budget.
+    expect(
+      (await rateLimit("ip-a", { limit: 1, windowMs: 60_000, prefix: "b" })).success,
+    ).toBe(true);
+  });
+
+  it("resets after the window elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const opts = { limit: 1, windowMs: 1_000, prefix: "win" };
+      expect((await rateLimit("ip", opts)).success).toBe(true);
+      expect((await rateLimit("ip", opts)).success).toBe(false);
+      vi.advanceTimersByTime(1_001);
+      expect((await rateLimit("ip", opts)).success).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("rate-limit — distributed (Upstash env present)", () => {
+  afterEach(clearUpstashEnv);
+
+  it("reports distributed when env vars are present", () => {
+    setUpstashEnv();
+    expect(isRateLimitDistributed()).toBe(true);
+  });
+
+  it("delegates to the Upstash limiter and maps the result", async () => {
+    setUpstashEnv();
+    const reset = Date.now() + 30_000;
+    limitMock.mockResolvedValue({ success: true, remaining: 7, reset });
+
+    const r = await rateLimit("9.9.9.9", { limit: 10, windowMs: 60_000, prefix: "dist" });
+
+    expect(limitMock).toHaveBeenCalledWith("9.9.9.9");
+    expect(r.success).toBe(true);
+    expect(r.remaining).toBe(7);
+    expect(r.retryAfterSeconds).toBeGreaterThan(0);
+    expect(r.retryAfterSeconds).toBeLessThanOrEqual(30);
+  });
+
+  it("returns blocked when the distributed limiter denies", async () => {
+    setUpstashEnv();
+    limitMock.mockResolvedValue({
+      success: false,
+      remaining: 0,
+      reset: Date.now() + 5_000,
+    });
+
+    const r = await rateLimit("9.9.9.9", { limit: 1, windowMs: 60_000, prefix: "dist2" });
+    expect(r.success).toBe(false);
+  });
+
+  it("falls back to in-memory when the distributed backend throws", async () => {
+    setUpstashEnv();
+    limitMock.mockRejectedValue(new Error("redis down"));
+
+    const opts = { limit: 1, windowMs: 60_000, prefix: "fallback" };
+    const r1 = await rateLimit("ip", opts);
+    const r2 = await rateLimit("ip", opts);
+
+    // First request allowed by the in-memory fallback, second blocked.
+    expect(r1.success).toBe(true);
+    expect(r2.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Per-instance `new Map()` rate limiters are ineffective on Vercel — each serverless/edge instance has isolated memory and counters reset on cold start, so limits are trivially bypassed (issue #12). This adds a shared limiter backed by Upstash Redis (provisioned via the Vercel Marketplace; "Vercel KV" is Upstash Redis under the hood) with a graceful in-memory fallback.

## Changes
- **`src/lib/rate-limit.ts`** (new): `rateLimit(identifier, { limit, windowMs, prefix })`.
  - Uses `@upstash/ratelimit` (fixed window) + `@upstash/redis` when `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are set.
  - **Graceful fallback** to an in-memory limiter when those env vars are absent (local dev / CI) **or** if a Redis call throws — it never takes the site down.
  - Works in both the Edge runtime (`proxy.ts`) and Node.js routes (REST/fetch-based client).
- **`src/proxy.ts`**: removed the global in-memory `Map`; the coarse 100 req / 15 min per-IP limit is now distributed and **scoped to `/api/*`** so we don't pay a Redis round-trip on every page view. `X-Rate-Limit-Remaining` still reported.
- **Per-route limiters** converted to the shared store, each preserving its existing limit/window: contact (5/10m), chat (10/15m), intake (5/10m), reviews (3/10m). Removed the chat route's `setInterval` cleanup (the shared store sweeps internally).
- **Tests** (`tests/unit/rate-limit.test.ts`, Upstash client mocked): in-memory allow→block, per-identifier/prefix isolation, window reset, distributed delegation + result mapping, blocked path, and Redis-failure fallback.

## ⚠️ Owner action required — provision the store
The code ships behind a fallback, so dev/CI/preview stay green **without** any store. To make rate limiting actually distributed in production, provision Upstash Redis and add its env vars:

1. **Vercel dashboard** → project `aetheris-vision-website` → **Storage** → **Create / Connect Store** → **Upstash Redis** (Marketplace). Or CLI:
   ```bash
   vercel link            # link this repo to the project first
   vercel integration add upstash
   ```
2. Connecting the store auto-injects **`UPSTASH_REDIS_REST_URL`** and **`UPSTASH_REDIS_REST_TOKEN`** into the project's environment (Production/Preview/Development).
3. Pull locally if you want to test the distributed path: `vercel env pull .env.local`.
4. No code change needed afterward — `rateLimit()` detects the env vars and switches to Redis automatically. Verify via the `X-Rate-Limit-Remaining` header / a 429 under load.

I could not provision non-interactively: the Marketplace flow needs plan selection + billing approval, and the repo isn't linked from this shell.

## Verification
- `tsc --noEmit` clean; `npm run lint` 0 errors; `npm test` **183 passing** (20 files); `npm run test:cucumber` **39 scenarios**; `next build` compiles + TypeScript passes (local page-data collection needs runtime secrets, provided by CI/Vercel).
- `npm audit`: 0 vulnerabilities (added `@upstash/ratelimit`, `@upstash/redis`).

Fixes #12

Made with [Cursor](https://cursor.com)