### PR TITLE
Right-size the privacy policy to match the site

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -8,7 +8,13 @@ export const metadata: Metadata = {
   description: "How Aetheris Vision LLC collects, uses, and protects your personal information.",
 };
 
-const EFFECTIVE_DATE = "March 1, 2026";
+const EFFECTIVE_DATE = "June 8, 2026";
+
+// NOTE (internal): This policy was right-sized to match what the site actually
+// does (analytics, processors, client portal). It is practical drafting, not
+// legal advice — whether CCPA/CPRA or GDPR formally apply to Aetheris Vision
+// (based on customer base, revenue thresholds, and data volume) should be
+// confirmed with counsel before relying on the rights language in §6.
 
 export default function PrivacyPage() {
   return (
@@ -100,6 +106,18 @@ export default function PrivacyPage() {
               </div>
 
               <div>
+                <h3 className="text-base font-semibold text-gray-200 mb-1">Client Portal</h3>
+                <p>
+                  If you are an Aetheris Vision client, the portal at{" "}
+                  <code className="text-gray-300">/client</code> lets you sign in with a
+                  one-time magic link sent to your email. We store your email address and the
+                  project, document, and invoice records associated with your engagement so we
+                  can deliver those services. Sign-in tokens are short-lived and deleted on use
+                  or expiry.
+                </p>
+              </div>
+
+              <div>
                 <h3 className="text-base font-semibold text-gray-200 mb-1">Server Logs</h3>
                 <p>
                   Our hosting provider, <strong className="text-gray-300">Vercel, Inc.</strong>, automatically
@@ -117,12 +135,26 @@ export default function PrivacyPage() {
 
           {/* 3 */}
           <section>
-            <h2 className="text-xl font-semibold text-white mb-3">3. Cookies and Tracking</h2>
+            <h2 className="text-xl font-semibold text-white mb-3">3. Cookies and Analytics</h2>
             <p>
-              This website does <strong className="text-gray-300">not</strong> use advertising
-              cookies, tracking pixels, or third-party analytics (e.g., Google Analytics).
-              No cookie consent banner is required because we do not set non-essential cookies.
+              We use a small amount of analytics to understand site traffic and improve the
+              website. We do <strong className="text-gray-300">not</strong> use advertising
+              cookies or sell any data.
             </p>
+            <ul className="mt-3 ml-4 space-y-1 list-disc list-outside">
+              <li>
+                <strong className="text-gray-300">Vercel Analytics</strong> &mdash; a
+                privacy-focused, cookieless analytics service that records aggregate page
+                views and performance metrics without using cookies or storing personally
+                identifying information.
+              </li>
+              <li>
+                <strong className="text-gray-300">Google Analytics (gtag)</strong> &mdash;
+                when enabled, Google Analytics measures site usage and sets first-party
+                analytics cookies in your browser. It is loaded only when an analytics
+                measurement ID is configured for the site.
+              </li>
+            </ul>
             <p className="mt-3">
               Fonts are served locally, so no requests are sent to Google Fonts or any other
               external font CDN when you visit this site.
@@ -149,9 +181,14 @@ export default function PrivacyPage() {
                 <tbody className="divide-y divide-white/5">
                   {[
                     ["Vercel", "Website hosting & CDN", "IP address, request logs"],
+                    ["Vercel Analytics", "Cookieless traffic analytics", "Aggregate page views, performance metrics"],
+                    ["Google Analytics", "Site usage analytics (when enabled)", "Usage events, analytics cookies"],
                     ["Formspree", "Contact form delivery", "Name, email, message content"],
                     ["Cal.com", "Appointment scheduling", "Name, email, booking details"],
                     ["GitHub / Giscus", "Blog comments", "GitHub account data"],
+                    ["Neon", "Database (client portal, submissions)", "Account email, project & document records"],
+                    ["Stripe", "Invoicing & payments", "Billing contact, invoice & payment details"],
+                    ["Docuseal", "Document e-signature", "Signer name, email, signed documents"],
                     ["Cloudflare", "DNS resolution", "IP address (DNS queries only)"],
                   ].map(([service, purpose, data]) => (
                     <tr key={service}>
@@ -164,10 +201,9 @@ export default function PrivacyPage() {
               </table>
             </div>
             <p className="mt-4 text-sm text-gray-500">
-              All processors are contractually bound to handle data only as directed and in
-              compliance with applicable law. Vercel, Formspree, and Cal.com are certified
-              under the EU-U.S. Data Privacy Framework or maintain Standard Contractual
-              Clauses (SCCs) for cross-border data transfers.
+              Each processor handles data under its own terms of service and privacy policy.
+              We share only the data necessary for the service shown above and do not sell
+              personal data.
             </p>
           </section>
 
@@ -206,47 +242,20 @@ export default function PrivacyPage() {
           {/* 6 */}
           <section>
             <h2 className="text-xl font-semibold text-white mb-3">6. Your Rights</h2>
-
-            <div className="space-y-4">
-              <div>
-                <h3 className="text-base font-semibold text-gray-200 mb-1">
-                  European Union and EEA Residents (GDPR)
-                </h3>
-                <p>Under the General Data Protection Regulation, you have the right to:</p>
-                <ul className="mt-2 ml-4 space-y-1 list-disc list-outside">
-                  <li>Access the personal data we hold about you</li>
-                  <li>Request correction of inaccurate data</li>
-                  <li>Request deletion (&quot;right to be forgotten&quot;)</li>
-                  <li>Object to processing based on legitimate interest</li>
-                  <li>Request restriction of processing</li>
-                  <li>Data portability</li>
-                  <li>Lodge a complaint with your national supervisory authority
-                    (in Sweden: Integritetsskyddsmyndigheten / IMY, imy.se)</li>
-                </ul>
-              </div>
-
-              <div>
-                <h3 className="text-base font-semibold text-gray-200 mb-1">
-                  California Residents (CCPA / CPRA)
-                </h3>
-                <p>Under the California Consumer Privacy Act, you have the right to:</p>
-                <ul className="mt-2 ml-4 space-y-1 list-disc list-outside">
-                  <li>Know what personal information is collected about you</li>
-                  <li>Know whether your personal information is sold or disclosed</li>
-                  <li>Opt out of the sale of your personal information
-                    (we do not sell personal information)</li>
-                  <li>Request deletion of your personal information</li>
-                  <li>Not be discriminated against for exercising your rights</li>
-                </ul>
-              </div>
-
-              <p>
-                To exercise any of these rights,{" "}
-                <a href="/contact?topic=Privacy%20Rights%20Request" className="text-blue-400 hover:underline">
-                  contact us
-                </a>. We will respond within 30 days.
-              </p>
-            </div>
+            <p>
+              You can ask us to access, correct, or delete the personal data we hold about
+              you, and you can object to or ask us to restrict how we use it. We do not sell
+              personal data. Depending on where you live, you may have additional rights under
+              laws such as the EU/UK GDPR or the California Consumer Privacy Act (CCPA/CPRA),
+              including the right to lodge a complaint with your local data protection
+              authority.
+            </p>
+            <p className="mt-3">
+              To exercise any of these rights,{" "}
+              <a href="/contact?topic=Privacy%20Rights%20Request" className="text-blue-400 hover:underline">
+                contact us
+              </a>. We will respond within 30 days.
+            </p>
           </section>
 
           {/* 7 */}
@@ -265,12 +274,12 @@ export default function PrivacyPage() {
           <section>
             <h2 className="text-xl font-semibold text-white mb-3">8. Children</h2>
             <p>
-              This website is directed to business and government professionals. We do not
-              knowingly collect personal information from persons under the age of 13. If
-              you believe a child has submitted data through this site,{" "}
+              This website is not directed to children, and we do not knowingly collect
+              personal information from anyone under the age of 13. If you believe a child
+              has provided us data,{" "}
               <a href="/contact" className="text-blue-400 hover:underline">
                 contact us
-              </a>{" "}immediately.
+              </a>{" "}and we will delete it.
             </p>
           </section>
 

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -112,8 +112,8 @@ export default function PrivacyPage() {
                   <code className="text-gray-300">/client</code> lets you sign in with a
                   one-time magic link sent to your email. We store your email address and the
                   project, document, and invoice records associated with your engagement so we
-                  can deliver those services. Sign-in tokens are short-lived and deleted on use
-                  or expiry.
+                  can deliver those services. Sign-in tokens are single-use and expire after 24
+                  hours; a token is deleted once used and is replaced if you request a new link.
                 </p>
               </div>
 
@@ -184,6 +184,7 @@ export default function PrivacyPage() {
                     ["Vercel Analytics", "Cookieless traffic analytics", "Aggregate page views, performance metrics"],
                     ["Google Analytics", "Site usage analytics (when enabled)", "Usage events, analytics cookies"],
                     ["Formspree", "Contact form delivery", "Name, email, message content"],
+                    ["Resend", "Transactional email (sign-in links, invoices)", "Recipient email address, message content"],
                     ["Cal.com", "Appointment scheduling", "Name, email, booking details"],
                     ["GitHub / Giscus", "Blog comments", "GitHub account data"],
                     ["Neon", "Database (client portal, submissions)", "Account email, project & document records"],
@@ -219,7 +220,7 @@ export default function PrivacyPage() {
                   <li><strong className="text-gray-300">Client portal accounts:</strong> retained for the duration of the client relationship plus 1 year after the final project is closed.</li>
                   <li><strong className="text-gray-300">Blog subscription emails:</strong> retained until you unsubscribe.</li>
                   <li><strong className="text-gray-300">Booking records:</strong> retained per Cal.com&apos;s data retention policy.</li>
-                  <li><strong className="text-gray-300">Magic link authentication tokens:</strong> automatically deleted upon use or expiry (24-hour window), whichever comes first.</li>
+                  <li><strong className="text-gray-300">Magic link authentication tokens:</strong> single-use and valid for 24 hours; deleted once used and replaced when you request a new link.</li>
                   <li><strong className="text-gray-300">Server logs:</strong> retained per Vercel&apos;s data retention policy (typically 30 days).</li>
                 </ul>
               </div>
@@ -276,7 +277,7 @@ export default function PrivacyPage() {
             <p>
               This website is not directed to children, and we do not knowingly collect
               personal information from anyone under the age of 13. If you believe a child
-              has provided us data,{" "}
+              has provided us with data,{" "}
               <a href="/contact" className="text-blue-400 hover:underline">
                 contact us
               </a>{" "}and we will delete it.


### PR DESCRIPTION
## Summary

Right-sizes `src/app/privacy/page.tsx` so the policy accurately reflects what the site actually does, removing false/overblown template content.

- **§3 Cookies & Analytics (was factually false):** the old text claimed "no Google Analytics / no non-essential cookies," but `layout.tsx` always loads **Vercel Analytics** and conditionally loads **Google Analytics (gtag)**. Rewrote §3 to describe Vercel Analytics (cookieless, aggregate) and Google Analytics (loaded only when a measurement ID is configured; sets first-party analytics cookies).
- **§4 Processor table:** added the real processors that were missing — **Vercel Analytics, Google Analytics, Neon** (database — client portal & submissions), **Stripe** (invoicing/payments), **Docuseal** (document e-signature) — each with purpose and data processed. Also softened the unverified "certified under EU-U.S. Data Privacy Framework / SCCs" claim to a factual statement.
- **§2:** added a **Client Portal** subsection (magic-link sign-in; we store account email and project/document/invoice records) — previously referenced by §5/§7 but never described.
- **§6 Your Rights:** trimmed the full GDPR+CCPA machinery to one concise, proportionate paragraph and **removed the stray Sweden / IMY** template leftover.
- **§8 Children:** tightened to the concise standard "not directed to children / don't knowingly collect under-13 data" line.
- Refreshed the effective date (June 8, 2026). All in-page contact points already route to `/contact` (from #64).

## ⚠️ For the owner / counsel
This is **practical right-sizing, not legal advice.** I added an internal source comment noting that whether **CCPA/CPRA or GDPR formally apply** to Aetheris Vision (based on customer base, revenue thresholds, and data volume) should be **confirmed with a lawyer** before relying on the §6 rights language.

## Verification
- `npm test` → **179 passed** (incl. the email-security mirror that renders the privacy page and asserts no address / `mailto:` and a `/contact` link)
- `npm run test:cucumber` → **37 scenarios / 161 steps passed**
- `npm run lint` → 0 errors
- `npm run build` → compiled successfully (local `aria-query 2` type-noise is the known duplicate-`@types` macOS artifact; clean CI install is unaffected)
- `npm audit` → unchanged (0)

## Test plan
- [ ] Review §3/§4 accuracy against current analytics config
- [ ] Have counsel confirm CCPA/GDPR applicability before relying on §6

Made with [Cursor](https://cursor.com)