### PR TITLE
Fix spacing in contact-form unavailable notice

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -335,7 +335,7 @@ export default function ContactForm() {
           <div role="status" className="rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-4 text-sm text-yellow-200">
             Our message form isn&apos;t accepting submissions right now. Please call or text{" "}
             <a href={CONTACT_PHONE_HREF} className="underline font-medium">{CONTACT_PHONE}</a>, or{" "}
-            <a href="/book" className="underline font-medium">book a call</a> and we&apos;ll follow up.
+            <a href="/book" className="underline font-medium">book a call</a>{" "}and we&apos;ll follow up.
           </div>
         )}
 

--- a/tests/unit/ContactForm.test.tsx
+++ b/tests/unit/ContactForm.test.tsx
@@ -32,6 +32,17 @@ function fillValidFields() {
   setField("message", "This is a valid message long enough.");
 }
 
+describe("ContactForm — unavailable notice", () => {
+  it("renders the notice with correct spacing around the links", () => {
+    render(<ContactForm />);
+    const notice = screen.getByRole("status");
+    // Collapse runtime whitespace and assert no words are glued together.
+    const text = notice.textContent?.replace(/\s+/g, " ").trim();
+    expect(text).toContain("or book a call and we'll follow up.");
+    expect(text).not.toMatch(/book a calland/);
+  });
+});
+
 describe("ContactForm — submit validation", () => {
   it("shows all required field errors when submitted empty", async () => {
     render(<ContactForm />);

--- a/tests/unit/ContactForm.test.tsx
+++ b/tests/unit/ContactForm.test.tsx
@@ -33,6 +33,15 @@ function fillValidFields() {
 }
 
 describe("ContactForm — unavailable notice", () => {
+  // Force the form into the unconfigured state so the notice always renders,
+  // regardless of whether NEXT_PUBLIC_FORMSPREE_ID is set in the dev shell.
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "");
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("renders the notice with correct spacing around the links", () => {
     render(<ContactForm />);
     const notice = screen.getByRole("status");


### PR DESCRIPTION
## Summary
Hardens the whitespace around the "book a call" link in the contact-form **unavailable** notice (the yellow box from #64 in `src/components/ContactForm.tsx`).

The link previously relied on an implicit JSX space (`</a> and we'll follow up.`). That renders correctly only because the markup sits on one line — a formatter reflow that moves `</a>` to a line end would strip the leading space and produce **"book a calland we'll follow up."** This replaces it with an explicit `{" "}` token so the space is guaranteed.

Audited the other link adjacencies in the same notice — the phone link and "or book a call" both already use explicit `{" "}`, so no other gaps.

## Verification
- Added a regression test asserting the notice reads "...or book a call and we'll follow up." with no glued words.
- `npm test`: 180 passing (was 179 + 1 new).
- `npm audit`: 0 vulnerabilities.
- Build compiles successfully (local TS check only hits the known macOS `@types/* 2` duplicate-folder artifact; CI clean install is unaffected).

## Note
A render probe showed the current `main` source already produces correct spacing in the DOM, so any live "calland" symptom is most likely a stale CDN/browser cache rather than the committed code. This change makes the spacing explicit and formatter-proof regardless.

Made with [Cursor](https://cursor.com)