### PR TITLE
feat(contact): deliver contact form via Resend instead of Formspree

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,11 +28,9 @@ ANTHROPIC_API_KEY="sk-ant-..."
 
 # ── Email (Resend) ───────────────────────────────────────────────────
 # Get from https://resend.com/api-keys
+# Used for magic-link sign-in, invoices, intake, AND the contact form.
+# When unset, the contact form returns 503 and shows its "unavailable" notice.
 RESEND_API_KEY="re_..."
-
-# ── Contact form (Formspree — optional) ─────────────────────────────
-# Sign up at https://formspree.io → create a form → paste the form ID
-NEXT_PUBLIC_FORMSPREE_ID="your-formspree-form-id"
 
 # ── Admin portal ─────────────────────────────────────────────────────
 # Simple password for /admin login (hashed server-side)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -66,7 +66,7 @@ tests/
 - Security headers set in `next.config.ts` (HSTS, X-Content-Type-Options, etc.).
 - Rate limiting on contact API route (5 requests/10 min per IP).
 - Honeypot field on contact form for bot detection.
-- Never commit secrets — use `.env.local` for `PREVIEW_PASSWORD`, `NEXT_PUBLIC_FORMSPREE_ID`.
+- Never commit secrets — use `.env.local` for `PREVIEW_PASSWORD`, `RESEND_API_KEY`.
 
 ## Build & Deploy
 - Local dev: `npm run dev`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,6 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          NEXT_PUBLIC_FORMSPREE_ID: ${{ secrets.NEXT_PUBLIC_FORMSPREE_ID }}
           PREVIEW_PASSWORD: ${{ secrets.PREVIEW_PASSWORD }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}

--- a/ATBD.md
+++ b/ATBD.md
@@ -211,7 +211,7 @@ Visitor types question → /api/chat (POST)
 |---|---|---|
 | Marketing pages | ✅ | 10 pages (Home, About, Capabilities, Portfolio, Blog, Book, Intake, Contact, Privacy, Security) |
 | Portfolio demos | ✅ | 7 live demo sites (law firm, restaurant, contractor, nonprofit, analytics dashboard, international market, portal pro) |
-| Contact form | ✅ | Server-validated, rate-limited, honeypot-protected, via Formspree |
+| Contact form | ✅ | Server-validated, rate-limited, honeypot-protected, delivered by email via Resend |
 | Blog | ✅ | Markdown-driven with categories, comments (Giscus), subscriptions |
 | Booking | ✅ | Cal.com embedded scheduling |
 | SEO | ✅ | JSON-LD (Organization, WebSite, LocalBusiness), OG images, dynamic sitemap, robots.txt |
@@ -651,7 +651,7 @@ export async function POST(req: NextRequest) {
 
 ### What is a database?
 
-A database is where your website stores information permanently. — all content is written directly in the code files. Blog posts are in `src/lib/posts.ts`. Contact form submissions go to Formspree's servers.
+A database is where your website stores information permanently. — all content is written directly in the code files. Blog posts are in `src/lib/posts.ts`. Contact form submissions are emailed to us via Resend.
 
 **Why would you need one?** Think of a database like a filing cabinet that your website can read from and write to automatically. Without it, you can't:
 
@@ -797,7 +797,7 @@ CRM stands for **Customer Relationship Management**. It's a system that tracks e
 **How does it connect to our website?** You can automatically create a contact in HubSpot every time someone fills out the website's contact form:
 
 ```typescript
-// src/app/api/contact/route.ts — after Formspree submission
+// src/app/api/contact/route.ts — after sending the contact email
 await fetch("https://api.hubapi.com/crm/v3/objects/contacts", {
   method: "POST",
   headers: {
@@ -877,7 +877,7 @@ export default async function LeadsPage() {
 
 How to send emails automatically from the website — like payment receipts, project updates, or welcome messages.
 
-**Why do you need programmatic email?** Right now, contact form submissions go to Formspree, which emails you. That works for a contact form. But for a real platform that has users, you need to send emails automatically — like when someone pays, or when you update their project status. You can't manually send every receipt.
+**Why do you need programmatic email?** The contact form already sends submissions to you by email via Resend. But for a real platform that has users, you need to send emails automatically — like when someone pays, or when you update their project status. You can't manually send every receipt.
 
 ### Recommended: Resend
 
@@ -980,7 +980,7 @@ Every website on the internet is constantly being probed by bots and attackers. 
 **The rule:** Anything with `NEXT_PUBLIC_` in the name is visible to EVERYONE who visits your site. The `NEXT_PUBLIC_` prefix tells Next.js "it's okay to send this to the browser." That's fine for things that are *meant* to be public (like a form endpoint). But it's catastrophic for things that should be secret (like a database password).
 
 ```
-✅ NEXT_PUBLIC_FORMSPREE_ID    → Safe (just a form endpoint)
+✅ NEXT_PUBLIC_GISCUS_REPO     → Safe (public repo identifier)
 ✅ NEXT_PUBLIC_STRIPE_PK       → Safe (publishable key, meant to be public)
 ❌ STRIPE_SECRET_KEY           → NEVER add NEXT_PUBLIC_ prefix
 ❌ DATABASE_URL                → NEVER add NEXT_PUBLIC_ prefix
@@ -1005,7 +1005,7 @@ Before you build a feature, you need to know what it costs to run. Some services
 | Cloudflare (DNS/CDN)     | $0 (Free plan)     |
 | Google Workspace (email) | $7.20              |
 | Cal.com (booking)        | $0 (Free plan)     |
-| Formspree (contact form) | $0 (Free plan)     |
+| Resend (email/contact)   | $0 (Free plan)     |
 | GitHub (code hosting)    | $0                 |
 | **Total**          | **$7.20/mo** |
 
@@ -1125,7 +1125,7 @@ Here's the exact sequence you'd follow:
 
 | Term                           | What It Means                                                                                                                                                          |
 | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **API**                  | Application Programming Interface — a way for two programs to talk to each other. When your website sends form data to Formspree, it's using Formspree's API.         |
+| **API**                  | Application Programming Interface — a way for two programs to talk to each other. When your website sends a contact email through Resend, it's using Resend's API.         |
 | **API Route**            | A server-side endpoint in your Next.js app (files in `src/app/api/`). It's code that runs on the server, not in the browser.                                         |
 | **Auth**                 | Short for Authentication — verifying who someone is when they log in.                                                                                                 |
 | **CRUD**                 | Create, Read, Update, Delete — the four basic things you can do with data in a database.                                                                              |

--- a/HOW_TO_BUILD_FROM_SCRATCH.md
+++ b/HOW_TO_BUILD_FROM_SCRATCH.md
@@ -111,7 +111,7 @@ The website code lives in a folder called `website` on your computer. We use **V
    cp .env.example .env.local
    ```
    You need two values:
-   - `NEXT_PUBLIC_FORMSPREE_ID` — your Formspree form ID (for the contact form)
+   - `RESEND_API_KEY` — your Resend API key (powers the contact form and transactional email)
    - `PREVIEW_PASSWORD` — a password for Vercel preview deployments
 7. Install the required tools:
    ```bash

--- a/README.md
+++ b/README.md
@@ -216,27 +216,28 @@ npm run test:watch    # Watch mode — re-runs tests automatically when you save
 
 ## Services Setup — How Each Feature Works
 
-### Contact Form (Formspree)
+### Contact Form (Resend)
 
-**What:** The contact page has a form where visitors can send us a message (their name, email, and what they need).
+**What:** The contact page has a form where visitors can send us a message (their name, email, organization, requirement type, and what they need).
 
-**Why Formspree?** We don't want to build our own email server — that's complicated and error-prone. Formspree handles receiving the form data and forwarding it to our email inbox. It's free for small volumes and takes 5 minutes to set up.
+**Why Resend?** The contact form delivers submissions by email through [Resend](https://resend.com) — the same provider already used for magic-link sign-in and invoice delivery. Reusing Resend avoids a separate third-party (Formspree) and its login friction, and sends from our already-verified `aetherisvision.com` domain.
 
-1. Sign up at [formspree.io](https://formspree.io) and create a new form.
-2. Copy the form ID from the form's endpoint URL (e.g. `https://formspree.io/f/xpwzabcd` → `xpwzabcd`).
-3. Add it to `.env.local`:
+The `POST /api/contact` route emails the submission to `contact@aetherisvision.com` (from `SITE.email`) with `replyTo` set to the submitter, so replies go straight back to them.
+
+1. Get an API key from [resend.com/api-keys](https://resend.com/api-keys).
+2. Add it to `.env.local`:
 
 ```bash
-NEXT_PUBLIC_FORMSPREE_ID="xpwzabcd"
+RESEND_API_KEY="re_..."
 ```
 
 For Vercel production:
 
 ```bash
-vercel env add NEXT_PUBLIC_FORMSPREE_ID production
+vercel env add RESEND_API_KEY production
 ```
 
-If `NEXT_PUBLIC_FORMSPREE_ID` is not set, the form falls back to opening the user's mail client with `mailto:contact@aetherisvision.com`.
+If `RESEND_API_KEY` is not set, the route returns 503 and the form shows an "unavailable" notice directing visitors to call/text or book a call.
 
 ### Blog Subscription
 

--- a/WEBSITE_MANUAL.md
+++ b/WEBSITE_MANUAL.md
@@ -80,7 +80,7 @@ aetherisvision.com (the domain, DNS managed by Cloudflare)
 **When a visitor fills out the contact form:**
 ```
 Visitor's browser → aetherisvision.com/api/contact (Vercel server)
-                       → Formspree (email delivery service)
+                       → Resend (email delivery service)
                            → contact@aetherisvision.com (your Gmail)
 ```
 
@@ -107,7 +107,7 @@ You need accounts on all of these services. All are free or already paid for.
 | Vercel | vercel.com | Hosts the website | GitHub login |
 | Cloudflare | cloudflare.com | Manages the domain's DNS | your email |
 | Google Workspace | admin.google.com | Business email | your email |
-| Formspree | formspree.io | Sends contact form emails | your email |
+| Resend | resend.com | Sends contact form emails (and sign-in links/invoices) | your email |
 | Cal.com | cal.com | Booking calendar | your email |
 | Giscus setup | giscus.app | Configures blog comments | GitHub login |
 
@@ -220,7 +220,7 @@ src/app/api/
   contact/
     route.ts            — The server-side contact form handler. When someone submits
                           the contact form, this code runs on Vercel's servers and
-                          forwards the message to Formspree. Visitors never see this
+                          emails the message via Resend. Visitors never see this
                           file — it runs invisibly in the background.
   chat/
     route.ts            — The server-side AI chat handler. Receives visitor messages,
@@ -517,15 +517,14 @@ They live in two places:
 - **How to change it:** Add `PREVIEW_PASSWORD=your-new-password` to Vercel env vars
 - **At go-live:** Remove this env var entirely AND remove the auth check from `src/middleware.ts`
 
-#### NEXT_PUBLIC_FORMSPREE_ID
-- **What it does:** The ID of your Formspree form. The contact form uses this to know where to send submissions.
+#### RESEND_API_KEY
+- **What it does:** API key for Resend. The contact form uses it to email submissions to `contact@aetherisvision.com` (it also powers sign-in links and invoices). If it is missing, the contact form returns 503 and shows an "unavailable" notice.
 - **How to get it:**
-  1. Log into formspree.io
-  2. Click your form ("Aetheris Vision Contact")
-  3. Look at the URL or the endpoint — it will say `https://formspree.io/f/xpwzabcd`
-  4. The ID is the last part: `xpwzabcd`
-- **Format:** 8-character alphanumeric string, e.g. `xpwzabcd`
-- **Where to put it:** Vercel → Settings → Environment Variables → `NEXT_PUBLIC_FORMSPREE_ID`
+  1. Log into resend.com
+  2. Go to **API Keys** → **Create API Key**
+  3. Copy the key (it starts with `re_`)
+- **Format:** string starting with `re_`
+- **Where to put it:** Vercel → Settings → Environment Variables → `RESEND_API_KEY` (server-only — do NOT prefix with `NEXT_PUBLIC_`)
 
 #### NEXT_PUBLIC_GISCUS_REPO
 - **What it does:** The GitHub repository where blog comments are stored.
@@ -549,13 +548,13 @@ They live in two places:
 
 ### What "NEXT_PUBLIC_" means
 
-Any variable starting with `NEXT_PUBLIC_` is visible in the browser to anyone who looks at the page source. This is fine for Giscus and Formspree IDs — they are not secret. Variables WITHOUT that prefix (like `PREVIEW_PASSWORD`) only exist on the server and are never visible to visitors.
+Any variable starting with `NEXT_PUBLIC_` is visible in the browser to anyone who looks at the page source. This is fine for Giscus IDs — they are not secret. Variables WITHOUT that prefix (like `PREVIEW_PASSWORD` and `RESEND_API_KEY`) only exist on the server and are never visible to visitors.
 
 ### How to add an environment variable to Vercel
 
 1. Go to vercel.com → your project → **Settings** → **Environment Variables**
 2. Click **Add New**
-3. Enter the name (e.g. `NEXT_PUBLIC_FORMSPREE_ID`) and value
+3. Enter the name (e.g. `RESEND_API_KEY`) and value
 4. Select **Production** (and optionally Preview and Development)
 5. Click **Save**
 6. **Important:** You must redeploy for the new variable to take effect. Go to the **Deployments** tab → click the three dots on the latest deployment → **Redeploy**
@@ -603,13 +602,13 @@ Any variable starting with `NEXT_PUBLIC_` is visible in the browser to anyone wh
 - **What you manage here:** DNS records (the A record and CNAME that point the domain to Vercel).
 - **You rarely need to go here** unless changing where the domain points.
 
-### Formspree (contact form email delivery)
-- **What it is:** A service that receives contact form submissions and emails them to you.
-- **Why:** Sending email directly from code requires a complex email server setup. Formspree handles all of that.
-- **How it works:** Your contact form sends data to Formspree's servers → Formspree emails it to `contact@aetherisvision.com`
-- **Free tier:** 50 submissions/month. Upgrade if you need more.
-- **Dashboard:** formspree.io
-- **Important:** The form submission is proxied through your own server (`/api/contact`) so ad-blockers cannot block it.
+### Resend (contact form email delivery)
+- **What it is:** The email API that delivers contact form submissions to you (and also sends sign-in links and invoices).
+- **Why:** Reuses the email provider already wired into the site, sending from the verified `aetherisvision.com` domain — no separate third-party login.
+- **How it works:** Your contact form posts to `/api/contact` → the server emails the submission via Resend to `contact@aetherisvision.com`, with `replyTo` set to the visitor so you can reply directly.
+- **Free tier:** generous monthly send allowance (see resend.com pricing).
+- **Dashboard:** resend.com
+- **Important:** The email is sent server-side from `/api/contact`, so the API key is never exposed to the browser. If `RESEND_API_KEY` is unset, the form returns 503 and shows an "unavailable" notice.
 
 ### Cal.com (booking)
 - **What it is:** An open-source calendar and booking service.
@@ -699,11 +698,11 @@ dig NS aetherisvision.com +short       # Should show Cloudflare nameservers
 
 1. Visitor fills out the form at `/contact`
 2. Browser sends data to `aetherisvision.com/api/contact` (your Vercel server)
-3. Vercel server forwards it to `formspree.io/f/[YOUR_FORM_ID]`
-4. Formspree emails the submission to `contact@aetherisvision.com`
-5. You receive it in Gmail
+3. The Vercel server emails the submission via Resend (from the verified `aetherisvision.com` domain)
+4. Resend delivers it to `contact@aetherisvision.com`, with `replyTo` set to the visitor
+5. You receive it in Gmail and can reply straight to the visitor
 
-The form is routed through your own server (not directly to Formspree from the visitor's browser) so that ad-blockers cannot intercept or block it.
+The email is sent server-side from `/api/contact` (not from the visitor's browser), so the Resend API key stays secret and ad-blockers cannot intercept the submission.
 
 ---
 
@@ -768,9 +767,9 @@ The CSP is the most complex security feature. Here's how it works:
 
 ### "The contact form shows an error"
 
-1. Check that `NEXT_PUBLIC_FORMSPREE_ID` is set in Vercel (Settings → Environment Variables)
-2. Make sure the value is ONLY the short ID (like `xpwzabcd`) — not the full URL
-3. Check formspree.io that your form is Active (not "awaiting confirmation")
+1. Check that `RESEND_API_KEY` is set in Vercel (Settings → Environment Variables). If it is missing, the form returns 503 and shows an "unavailable" notice.
+2. Make sure the value is the full key starting with `re_` and has not been revoked in the Resend dashboard.
+3. Confirm the `aetherisvision.com` sending domain is verified in Resend (Domains tab).
 4. After changing env vars, you must redeploy: Vercel → Deployments → Redeploy
 
 ### "The blog comments section is not showing"
@@ -874,7 +873,7 @@ export const metadata = {
 ### Routine tasks
 
 **Monthly:**
-- Check formspree.io submission count (free tier: 50/month). Upgrade if needed.
+- Check resend.com email usage against your plan's monthly send allowance. Upgrade if needed.
 - Review any GitHub Discussions (blog comments) that need moderation.
 - Check Vercel dashboard for any deployment errors.
 

--- a/scripts/check-env.js
+++ b/scripts/check-env.js
@@ -6,10 +6,6 @@ const requiredGroups = [
     keys: ["NEXT_PUBLIC_BLOG_SUBSCRIBE_URL"],
   },
   {
-    label: "Contact form (Formspree)",
-    keys: ["NEXT_PUBLIC_FORMSPREE_ID"],
-  },
-  {
     label: "Blog comments (Giscus)",
     keys: [
       "NEXT_PUBLIC_GISCUS_REPO",

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,11 +1,32 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Resend } from "resend";
 import { SITE } from "@/lib/constants";
 import { rateLimit } from "@/lib/rate-limit";
+
+// Contact submissions are delivered by email through Resend — the same
+// provider already used for magic-link sign-in and invoice delivery. This
+// removes the Formspree login dependency and reuses our verified sending
+// domain (aetherisvision.com).
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+// Notifications are sent from the verified Resend domain; replies are routed
+// back to the submitter via replyTo.
+const FROM_ADDRESS = "Aetheris Vision <system@aetherisvision.com>";
 
 // Rate limit: 5 submissions per IP per 10 minutes. Distributed across Vercel
 // instances when Upstash/Vercel KV is configured, else in-memory (issue #12).
 const RATE_LIMIT = 5;
 const WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+
+/** Escape user-supplied text before interpolating it into the HTML email. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
 
 export async function POST(req: NextRequest) {
   // ── Rate limiting ──────────────────────────────────────────────────────────
@@ -25,8 +46,9 @@ export async function POST(req: NextRequest) {
   }
 
   // ── Config check ───────────────────────────────────────────────────────────
-  const FORMSPREE_ID = process.env.NEXT_PUBLIC_FORMSPREE_ID;
-  if (!FORMSPREE_ID) {
+  // Without a Resend API key the form cannot deliver mail; return 503 so the UI
+  // shows its "form unavailable" notice instead of silently dropping messages.
+  if (!process.env.RESEND_API_KEY) {
     return NextResponse.json({ error: "Form not configured" }, { status: 503 });
   }
 
@@ -44,6 +66,8 @@ export async function POST(req: NextRequest) {
   const name = data.name?.trim();
   const email = data.email?.trim();
   const message = data.message?.trim();
+  const organization = data.organization?.trim() ?? "";
+  const requirement = data.requirement?.trim() ?? "";
 
   if (!name || name.length < 2 || name.length > 200) {
     return NextResponse.json(
@@ -66,18 +90,50 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  // ── Forward to Formspree ───────────────────────────────────────────────────
-  const res = await fetch(`https://formspree.io/f/${FORMSPREE_ID}`, {
-    method: "POST",
-    body: JSON.stringify(data),
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      Referer: SITE.url,
-      Origin: SITE.url,
-    },
+  // ── Deliver via Resend ──────────────────────────────────────────────────────
+  const subjectLine = requirement
+    ? `New contact form submission — ${requirement}`
+    : "New contact form submission";
+
+  const textBody = [
+    `Name: ${name}`,
+    `Email: ${email}`,
+    organization ? `Organization: ${organization}` : "Organization: —",
+    requirement ? `Requirement: ${requirement}` : "Requirement: —",
+    "",
+    "Message:",
+    message,
+  ].join("\n");
+
+  const htmlBody = `
+    <div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto;padding:24px;color:#0f172a;">
+      <h2 style="margin:0 0 16px;">New contact form submission</h2>
+      <table style="width:100%;border-collapse:collapse;font-size:14px;">
+        <tr><td style="padding:4px 0;color:#64748b;width:120px;">Name</td><td style="padding:4px 0;">${escapeHtml(name)}</td></tr>
+        <tr><td style="padding:4px 0;color:#64748b;">Email</td><td style="padding:4px 0;"><a href="mailto:${escapeHtml(email)}">${escapeHtml(email)}</a></td></tr>
+        <tr><td style="padding:4px 0;color:#64748b;">Organization</td><td style="padding:4px 0;">${organization ? escapeHtml(organization) : "—"}</td></tr>
+        <tr><td style="padding:4px 0;color:#64748b;">Requirement</td><td style="padding:4px 0;">${requirement ? escapeHtml(requirement) : "—"}</td></tr>
+      </table>
+      <h3 style="margin:24px 0 8px;font-size:14px;color:#64748b;text-transform:uppercase;letter-spacing:0.05em;">Message</h3>
+      <p style="white-space:pre-wrap;font-size:15px;line-height:1.6;margin:0;">${escapeHtml(message)}</p>
+    </div>
+  `;
+
+  const { error } = await resend.emails.send({
+    from: FROM_ADDRESS,
+    to: [SITE.email],
+    replyTo: email,
+    subject: subjectLine,
+    text: textBody,
+    html: htmlBody,
   });
 
-  const body = await res.json().catch(() => ({}));
-  return NextResponse.json(body, { status: res.status });
+  if (error) {
+    return NextResponse.json(
+      { error: "Failed to send message. Please try again." },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({ ok: true });
 }

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -11,12 +11,22 @@ const resend = new Resend(process.env.RESEND_API_KEY);
 
 // Notifications are sent from the verified Resend domain; replies are routed
 // back to the submitter via replyTo.
-const FROM_ADDRESS = "Aetheris Vision <system@aetherisvision.com>";
+const FROM_ADDRESS = `${SITE.name} <system@aetherisvision.com>`;
 
 // Rate limit: 5 submissions per IP per 10 minutes. Distributed across Vercel
 // instances when Upstash/Vercel KV is configured, else in-memory (issue #12).
 const RATE_LIMIT = 5;
 const WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+
+/** Safely read a string field from untrusted JSON (non-strings → ""). */
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+/** Collapse CR/LF so untrusted values cannot inject email header lines. */
+function singleLine(value: string, max: number): string {
+  return value.replace(/[\r\n]+/g, " ").trim().slice(0, max);
+}
 
 /** Escape user-supplied text before interpolating it into the HTML email. */
 function escapeHtml(value: string): string {
@@ -52,22 +62,23 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Form not configured" }, { status: 503 });
   }
 
-  const data: Record<string, string> = await req.json();
+  const data: Record<string, unknown> = await req.json();
 
   // ── Honeypot check ─────────────────────────────────────────────────────────
   // Bots fill in hidden fields. Humans never see this field so it stays blank.
-  if (data._gotcha) {
+  if (asString(data._gotcha)) {
     // Return 200 to fool the bot into thinking it succeeded
     return NextResponse.json({ ok: true });
   }
-  delete data._gotcha;
 
   // ── Input validation ───────────────────────────────────────────────────────
-  const name = data.name?.trim();
-  const email = data.email?.trim();
-  const message = data.message?.trim();
-  const organization = data.organization?.trim() ?? "";
-  const requirement = data.requirement?.trim() ?? "";
+  // Fields come from untrusted JSON; coerce non-strings to "" so a crafted
+  // payload (e.g. name: 123) yields a 400 rather than throwing a 500.
+  const name = asString(data.name).trim();
+  const email = asString(data.email).trim();
+  const message = asString(data.message).trim();
+  const organization = asString(data.organization).trim();
+  const requirement = asString(data.requirement).trim();
 
   if (!name || name.length < 2 || name.length > 200) {
     return NextResponse.json(
@@ -91,8 +102,11 @@ export async function POST(req: NextRequest) {
   }
 
   // ── Deliver via Resend ──────────────────────────────────────────────────────
-  const subjectLine = requirement
-    ? `New contact form submission — ${requirement}`
+  // Strip CR/LF and cap length before placing requirement in the subject so a
+  // crafted value cannot inject additional email headers.
+  const subjectRequirement = singleLine(requirement, 100);
+  const subjectLine = subjectRequirement
+    ? `New contact form submission — ${subjectRequirement}`
     : "New contact form submission";
 
   const textBody = [

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -49,7 +49,7 @@ export default function PrivacyPage() {
                 <strong className="text-gray-300">Contact form</strong> &mdash; when you submit
                 the form at <code className="text-gray-300">/contact</code>, we collect your
                 name, email, and message so we can respond to your inquiry. Submissions are
-                delivered through Formspree.
+                delivered to us by email through Resend.
               </li>
               <li>
                 <strong className="text-gray-300">Analytics</strong> &mdash; Vercel Analytics
@@ -74,12 +74,11 @@ export default function PrivacyPage() {
             <ul className="mt-3 ml-4 space-y-2 list-disc list-outside">
               <li><strong className="text-gray-300">Vercel</strong> &mdash; website hosting and CDN (processes request logs and IP addresses).</li>
               <li><strong className="text-gray-300">Vercel Analytics</strong> &mdash; cookieless, aggregate website analytics.</li>
-              <li><strong className="text-gray-300">Formspree</strong> &mdash; contact form delivery.</li>
               <li><strong className="text-gray-300">Google Analytics</strong> &mdash; site usage analytics, loaded only when a measurement ID is configured.</li>
               <li><strong className="text-gray-300">Neon</strong> &mdash; database for client-portal accounts and records.</li>
               <li><strong className="text-gray-300">Stripe</strong> &mdash; invoicing and payment processing.</li>
               <li><strong className="text-gray-300">Docuseal</strong> &mdash; document e-signature.</li>
-              <li><strong className="text-gray-300">Resend</strong> &mdash; transactional email (sign-in links and invoices).</li>
+              <li><strong className="text-gray-300">Resend</strong> &mdash; transactional email (sign-in links, invoices, and contact form delivery).</li>
             </ul>
             <p className="mt-3 text-sm text-gray-500">
               Each provider processes data under its own terms and privacy policy. We share only

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -88,11 +88,11 @@ function validateAll(fields: Fields): FieldErrors {
 }
 
 export default function ContactForm() {
-  // The form posts to /api/contact, which forwards to Formspree. When
-  // NEXT_PUBLIC_FORMSPREE_ID is not configured, the form cannot deliver
-  // messages, so we surface a clear notice and point visitors to the phone /
+  // The form posts to /api/contact, which delivers the message by email via
+  // Resend. Whether delivery is configured depends on the server-only
+  // RESEND_API_KEY, so the client cannot know up front; if the API returns 503
+  // we surface a clear "unavailable" notice pointing visitors to the phone /
   // scheduling alternatives instead of silently failing.
-  const formEnabled = Boolean(process.env.NEXT_PUBLIC_FORMSPREE_ID);
 
   // Optional prefill of the message field from a ?topic= (or ?subject=)
   // query param, e.g. /contact?topic=Capabilities%20Statement%20PDF%20Request.
@@ -139,13 +139,6 @@ export default function ContactForm() {
     }
     setFieldErrors({});
 
-    // NEXT_PUBLIC_FORMSPREE_ID is statically inlined at build time; reading it
-    // here keeps the gate alongside the submit logic (and lets tests stub it).
-    if (!process.env.NEXT_PUBLIC_FORMSPREE_ID) {
-      setStatus("unavailable");
-      return;
-    }
-
     setStatus("submitting");
     setErrorDetail("");
 
@@ -167,6 +160,8 @@ export default function ContactForm() {
         setFields(EMPTY);
         setFieldErrors({});
         setTouched({});
+      } else if (res.status === 503) {
+        setStatus("unavailable");
       } else if (res.status === 429) {
         setErrorDetail("Too many submissions. Please wait a few minutes and try again.");
         setStatus("error");
@@ -331,18 +326,12 @@ export default function ContactForm() {
           {fieldErrors.message && <p role="alert" className="mt-1.5 text-xs text-red-400">{fieldErrors.message}</p>}
         </div>
 
-        {!formEnabled && (
+        {status === "unavailable" && (
           <div role="status" className="rounded-md border border-yellow-500/30 bg-yellow-500/[0.06] p-4 text-sm text-yellow-200">
             Our message form isn&apos;t accepting submissions right now. Please call or text{" "}
             <a href={CONTACT_PHONE_HREF} className="underline font-medium">{CONTACT_PHONE}</a>, or{" "}
             <a href="/book" className="underline font-medium">book a call</a>{" "}and we&apos;ll follow up.
           </div>
-        )}
-
-        {status === "unavailable" && (
-          <p className="text-sm text-yellow-300">
-            The form is temporarily unavailable. Please call or text {CONTACT_PHONE}, or book a call above.
-          </p>
         )}
 
         {status === "error" && (

--- a/tests/features/contact-form.feature
+++ b/tests/features/contact-form.feature
@@ -6,24 +6,24 @@ Feature: Contact Form
   # ── API layer ──────────────────────────────────────────────────────────────
 
   Scenario: Visitor submits a valid contact request
-    Given the contact API is configured with Formspree
+    Given the contact API is configured with Resend
     When a visitor submits the form with name "Jane Doe" email "jane@example.com" and message "Need a custom website for my business"
-    Then the submission should be forwarded to Formspree
+    Then the submission should be emailed via Resend
     And the response status should be 200
 
   Scenario: Bot triggers the honeypot
-    Given the contact API is configured with Formspree
+    Given the contact API is configured with Resend
     When a bot submits the form with the honeypot field filled
     Then the response status should be 200
-    And the submission should not be forwarded to Formspree
+    And the submission should not be emailed via Resend
 
   Scenario: Rate limiting kicks in after too many requests
-    Given the contact API is configured with Formspree
+    Given the contact API is configured with Resend
     When 6 submissions come from the same IP address
     Then the 6th response status should be 429
 
   Scenario: Form configuration missing
-    Given Formspree is not configured
+    Given Resend is not configured
     When a visitor submits the form with name "Test" email "test@test.com" and message "Hello"
     Then the response status should be 503
 

--- a/tests/features/step-definitions/contact-form.steps.ts
+++ b/tests/features/step-definitions/contact-form.steps.ts
@@ -20,8 +20,11 @@ let apiResponse: Response;
 let fetchCallCount = 0;
 
 const originalFetch = globalThis.fetch;
-const originalFormspreeId = process.env.NEXT_PUBLIC_FORMSPREE_ID;
+const originalResendKey = process.env.RESEND_API_KEY;
 
+// The route delivers via the Resend SDK, which calls the global `fetch`. We
+// stub fetch to mimic a successful Resend API response (the SDK reads
+// `response.headers.entries()` on the ok path, so headers must be present).
 function installMockFetch(): void {
   fetchCallCount = 0;
   globalThis.fetch = (async () => {
@@ -29,7 +32,8 @@ function installMockFetch(): void {
     return {
       ok: true,
       status: 200,
-      json: async () => ({ ok: true }),
+      headers: new Headers(),
+      json: async () => ({ id: "email_test" }),
     } as unknown as Response;
   }) as typeof fetch;
 }
@@ -51,14 +55,14 @@ function uniqueIp(): string {
   return `bdd-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
-Given("the contact API is configured with Formspree", async function () {
-  process.env.NEXT_PUBLIC_FORMSPREE_ID = "test123";
+Given("the contact API is configured with Resend", async function () {
+  process.env.RESEND_API_KEY = "re_test_key";
   installMockFetch();
   await loadRoute();
 });
 
-Given("Formspree is not configured", async function () {
-  process.env.NEXT_PUBLIC_FORMSPREE_ID = "";
+Given("Resend is not configured", async function () {
+  process.env.RESEND_API_KEY = "";
   installMockFetch();
   await loadRoute();
 });
@@ -91,12 +95,12 @@ When("{int} submissions come from the same IP address", async function (count: n
   }
 });
 
-Then("the submission should be forwarded to Formspree", function () {
-  assert.ok(fetchCallCount > 0, "Expected the submission to be forwarded to Formspree");
+Then("the submission should be emailed via Resend", function () {
+  assert.ok(fetchCallCount > 0, "Expected the submission to be emailed via Resend");
 });
 
-Then("the submission should not be forwarded to Formspree", function () {
-  assert.equal(fetchCallCount, 0, "Submission should not have been forwarded to Formspree");
+Then("the submission should not be emailed via Resend", function () {
+  assert.equal(fetchCallCount, 0, "Submission should not have been emailed via Resend");
 });
 
 Then("the response status should be {int}", function (status: number) {
@@ -178,14 +182,12 @@ When("they click submit", function () {
 });
 
 When("the API responds with success", function () {
-  process.env.NEXT_PUBLIC_FORMSPREE_ID = "test123";
   globalThis.fetch = (async () =>
     ({ ok: true, status: 200, json: async () => ({ ok: true }) }) as unknown as Response) as typeof fetch;
   clickSubmit();
 });
 
 When("the API responds with a server error", function () {
-  process.env.NEXT_PUBLIC_FORMSPREE_ID = "test123";
   globalThis.fetch = (async () =>
     ({ ok: false, status: 500, json: async () => ({}) }) as unknown as Response) as typeof fetch;
   clickSubmit();
@@ -220,10 +222,10 @@ Then("they should see an error message with contact instructions", async functio
 
 After(function () {
   globalThis.fetch = originalFetch;
-  if (originalFormspreeId === undefined) {
-    delete process.env.NEXT_PUBLIC_FORMSPREE_ID;
+  if (originalResendKey === undefined) {
+    delete process.env.RESEND_API_KEY;
   } else {
-    process.env.NEXT_PUBLIC_FORMSPREE_ID = originalFormspreeId;
+    process.env.RESEND_API_KEY = originalResendKey;
   }
   form = null;
 });

--- a/tests/features/steps/contact-form.steps.test.ts
+++ b/tests/features/steps/contact-form.steps.test.ts
@@ -5,6 +5,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
  * These follow Given/When/Then structure matching the Gherkin scenarios.
  */
 
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }));
+
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = { send: sendMock };
+  },
+}));
+
 let POST: (req: Request) => Promise<Response>;
 
 function makeFormRequest(
@@ -23,14 +31,11 @@ describe("Feature: Contact Form", () => {
     let response: Response;
 
     beforeEach(async () => {
-      // Given the contact API is configured with Formspree
+      // Given the contact API is configured with Resend
       vi.resetModules();
-      vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "test123");
-      const mockFetch = vi.fn().mockResolvedValue({
-        status: 200,
-        json: () => Promise.resolve({ ok: true }),
-      });
-      vi.stubGlobal("fetch", mockFetch);
+      vi.stubEnv("RESEND_API_KEY", "re_test_key");
+      sendMock.mockReset();
+      sendMock.mockResolvedValue({ data: { id: "email_123" }, error: null });
 
       const mod = await import("@/app/api/contact/route");
       POST = mod.POST as unknown as (req: Request) => Promise<Response>;
@@ -47,20 +52,20 @@ describe("Feature: Contact Form", () => {
     it("Then the response status should be 200", () => {
       expect(response.status).toBe(200);
     });
+
+    it("And the submission should be emailed via Resend", () => {
+      expect(sendMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("Scenario: Bot triggers the honeypot", () => {
     let response: Response;
-    let mockFetch: ReturnType<typeof vi.fn>;
 
     beforeEach(async () => {
       vi.resetModules();
-      vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "test123");
-      mockFetch = vi.fn().mockResolvedValue({
-        status: 200,
-        json: () => Promise.resolve({ ok: true }),
-      });
-      vi.stubGlobal("fetch", mockFetch);
+      vi.stubEnv("RESEND_API_KEY", "re_test_key");
+      sendMock.mockReset();
+      sendMock.mockResolvedValue({ data: { id: "email_123" }, error: null });
 
       const mod = await import("@/app/api/contact/route");
       POST = mod.POST as unknown as (req: Request) => Promise<Response>;
@@ -79,22 +84,17 @@ describe("Feature: Contact Form", () => {
       expect(response.status).toBe(200);
     });
 
-    it("And the submission should not be forwarded to Formspree", () => {
-      expect(mockFetch).not.toHaveBeenCalled();
+    it("And the submission should not be emailed via Resend", () => {
+      expect(sendMock).not.toHaveBeenCalled();
     });
   });
 
   describe("Scenario: Rate limiting kicks in after too many requests", () => {
     it("Then the 6th response from the same IP should be 429", async () => {
       vi.resetModules();
-      vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "test123");
-      vi.stubGlobal(
-        "fetch",
-        vi.fn().mockResolvedValue({
-          status: 200,
-          json: () => Promise.resolve({ ok: true }),
-        })
-      );
+      vi.stubEnv("RESEND_API_KEY", "re_test_key");
+      sendMock.mockReset();
+      sendMock.mockResolvedValue({ data: { id: "email_123" }, error: null });
 
       const mod = await import("@/app/api/contact/route");
       const localPOST = mod.POST as unknown as (req: Request) => Promise<Response>;
@@ -108,15 +108,13 @@ describe("Feature: Contact Form", () => {
         makeFormRequest({ name: "T", email: "t@t.com", message: "too many" }, ip)
       );
       expect(res.status).toBe(429);
-
-      vi.unstubAllGlobals();
     });
   });
 
   describe("Scenario: Form configuration missing", () => {
     it("Then the response status should be 503", async () => {
       vi.resetModules();
-      vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "");
+      vi.stubEnv("RESEND_API_KEY", "");
 
       const mod = await import("@/app/api/contact/route");
       const localPOST = mod.POST as unknown as (req: Request) => Promise<Response>;
@@ -124,7 +122,7 @@ describe("Feature: Contact Form", () => {
       const req = makeFormRequest({
         name: "Test",
         email: "test@test.com",
-        message: "Hello",
+        message: "Hello there",
       });
       const res = await localPOST(req);
       expect(res.status).toBe(503);

--- a/tests/integration/contact-api.test.ts
+++ b/tests/integration/contact-api.test.ts
@@ -143,4 +143,16 @@ describe("POST /api/contact", () => {
     const body = await res.json();
     expect(body.error).toMatch(/message/i);
   });
+
+  it("returns 400 (not 500) for non-string field values", async () => {
+    // Crafted payload with a numeric name — must not throw.
+    const req = new Request("http://localhost:3000/api/contact", {
+      method: "POST",
+      body: JSON.stringify({ name: 123, email: "a@b.com", message: "Valid message here" }),
+      headers: { "x-forwarded-for": "127.0.0.1", "Content-Type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
 });

--- a/tests/integration/contact-api.test.ts
+++ b/tests/integration/contact-api.test.ts
@@ -1,16 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // We test the route handler's logic by importing and calling POST directly.
-// Must mock fetch for Formspree calls.
+// The route delivers submissions through Resend, so we mock the SDK and assert
+// against the mocked `emails.send`.
 
-// Reset module state between tests
+const { sendMock } = vi.hoisted(() => ({ sendMock: vi.fn() }));
+
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = { send: sendMock };
+  },
+}));
+
 let POST: (req: Request) => Promise<Response>;
 
 beforeEach(async () => {
   vi.resetModules();
-  vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "test123");
+  vi.stubEnv("RESEND_API_KEY", "re_test_key");
+  sendMock.mockReset();
+  sendMock.mockResolvedValue({ data: { id: "email_123" }, error: null });
 
-  // Mock NextRequest / NextResponse using the actual classes
   const mod = await import("@/app/api/contact/route");
   POST = mod.POST as unknown as (req: Request) => Promise<Response>;
 });
@@ -27,82 +36,88 @@ function makeRequest(body: Record<string, string>, ip = "127.0.0.1"): Request {
 }
 
 describe("POST /api/contact", () => {
-  it("returns 503 when FORMSPREE_ID is not set", async () => {
-    vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "");
+  it("returns 503 when RESEND_API_KEY is not set", async () => {
+    vi.stubEnv("RESEND_API_KEY", "");
     vi.resetModules();
     const mod = await import("@/app/api/contact/route");
     const localPOST = mod.POST as unknown as (req: Request) => Promise<Response>;
 
-    const req = makeRequest({ name: "Test", email: "test@test.com", message: "Hi" });
+    const req = makeRequest({ name: "Test", email: "test@test.com", message: "Hi there friend" });
     const res = await localPOST(req);
     expect(res.status).toBe(503);
+    expect(sendMock).not.toHaveBeenCalled();
   });
 
-  it("silently accepts honeypot submissions (returns 200)", async () => {
+  it("silently accepts honeypot submissions (returns 200) without sending email", async () => {
     const req = makeRequest({
       name: "Bot",
       email: "bot@bot.com",
-      message: "spam",
+      message: "spam message here",
       _gotcha: "filled-by-bot",
     });
     const res = await POST(req);
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.ok).toBe(true);
+    expect(sendMock).not.toHaveBeenCalled();
   });
 
-  it("forwards valid submissions to Formspree", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      status: 200,
-      json: () => Promise.resolve({ ok: true }),
+  it("sends valid submissions via Resend", async () => {
+    const req = makeRequest({
+      name: "John",
+      email: "john@agency.gov",
+      organization: "Acme Agency",
+      requirement: "Federal Contracting",
+      message: "Need consulting services for our agency",
     });
-    vi.stubGlobal("fetch", mockFetch);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
 
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    const payload = sendMock.mock.calls[0][0];
+    // Replies route back to the submitter
+    expect(payload.replyTo).toBe("john@agency.gov");
+    // Delivered to the canonical contact inbox
+    expect(payload.to).toContain("contact@aetherisvision.com");
+    // From the verified Resend domain
+    expect(payload.from).toMatch(/@aetherisvision\.com/);
+    // Body carries the submission details
+    expect(payload.text).toContain("john@agency.gov");
+    expect(payload.text).toContain("Acme Agency");
+    expect(payload.text).toContain("Federal Contracting");
+    expect(payload.text).toContain("Need consulting services for our agency");
+  });
+
+  it("returns 502 when Resend reports an error", async () => {
+    sendMock.mockResolvedValue({ data: null, error: { message: "domain not verified" } });
     const req = makeRequest({
       name: "John",
       email: "john@agency.gov",
       message: "Need consulting services for our agency",
     });
     const res = await POST(req);
-    expect(res.status).toBe(200);
-
-    // Verify Formspree was called
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://formspree.io/f/test123",
-      expect.objectContaining({ method: "POST" })
-    );
-
-    vi.unstubAllGlobals();
+    expect(res.status).toBe(502);
   });
 
   it("rate limits after 5 requests from same IP", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      status: 200,
-      json: () => Promise.resolve({ ok: true }),
-    });
-    vi.stubGlobal("fetch", mockFetch);
-
-    // Reset modules to get fresh rate limiter
     vi.resetModules();
-    vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "test123");
+    vi.stubEnv("RESEND_API_KEY", "re_test_key");
     const mod = await import("@/app/api/contact/route");
     const localPOST = mod.POST as unknown as (req: Request) => Promise<Response>;
 
     const testIp = `rate-limit-test-${Date.now()}`;
 
-    // Send 5 requests (should all succeed)
     for (let i = 0; i < 5; i++) {
       const req = makeRequest({ name: "Test", email: "t@t.com", message: `Message number ${i} with enough length` }, testIp);
       const res = await localPOST(req);
       expect(res.status).toBe(200);
     }
 
-    // 6th request should be rate limited
     const req = makeRequest({ name: "Test", email: "t@t.com", message: "This message is long enough now" }, testIp);
     const res = await localPOST(req);
     expect(res.status).toBe(429);
-
-    vi.unstubAllGlobals();
   });
 
   it("rejects empty name", async () => {

--- a/tests/unit/ContactForm.test.tsx
+++ b/tests/unit/ContactForm.test.tsx
@@ -33,18 +33,22 @@ function fillValidFields() {
 }
 
 describe("ContactForm — unavailable notice", () => {
-  // Force the form into the unconfigured state so the notice always renders,
-  // regardless of whether NEXT_PUBLIC_FORMSPREE_ID is set in the dev shell.
-  beforeEach(() => {
-    vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "");
-  });
+  // The form can't know server-side config up front, so the "unavailable"
+  // notice is surfaced reactively when the API returns 503 (RESEND_API_KEY
+  // unset). Simulate that response and assert the notice renders.
   afterEach(() => {
-    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
   });
 
-  it("renders the notice with correct spacing around the links", () => {
+  it("renders the notice with correct spacing around the links after a 503", async () => {
+    vi.stubGlobal("fetch", vi.fn(() =>
+      Promise.resolve({ ok: false, status: 503, json: () => Promise.resolve({ error: "Form not configured" }) })
+    ));
     render(<ContactForm />);
-    const notice = screen.getByRole("status");
+    fillValidFields();
+    fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+
+    const notice = await screen.findByRole("status");
     // Collapse runtime whitespace and assert no words are glued together.
     const text = notice.textContent?.replace(/\s+/g, " ").trim();
     expect(text).toContain("or book a call and we'll follow up.");
@@ -190,12 +194,7 @@ describe("ContactForm — character count", () => {
 });
 
 describe("ContactForm — submission", () => {
-  beforeEach(() => {
-    vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "test123");
-  });
-
   afterEach(() => {
-    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   });
 


### PR DESCRIPTION
## Summary

Switches the contact form submission backend from **Formspree** to **Resend** — the email provider already wired into this stack for magic-link sign-in and invoice delivery. This removes the separate Formspree third-party (and its login friction) and sends from our already-verified `aetherisvision.com` domain.

The custom contact form UI is unchanged: branding, inline validation, character counter, honeypot, and the `?topic=` / `?subject=` query-param prefill all behave exactly as before.

### What changed
- **`src/app/api/contact/route.ts`** — now emails each submission via Resend to `contact@aetherisvision.com` (`SITE.email`), with `replyTo` set to the submitter so replies go straight back to them. The email body includes name, email, organization, requirement type, and message (HTML + text, with HTML-escaped values).
  - Preserves existing protections: per-IP rate limiting (5 / 10 min), honeypot (`_gotcha`), and input validation.
  - **Graceful fallback:** returns `503` when `RESEND_API_KEY` is unset (same status the UI already keys its "form unavailable" notice off of). Returns `502` if Resend reports a delivery error. No `console.log` in the production path.
- **`src/components/ContactForm.tsx`** — the "unavailable" notice is now surfaced **reactively** when the API returns `503`. `RESEND_API_KEY` is a server-only secret and can't be read at build time the way the old public `NEXT_PUBLIC_FORMSPREE_ID` could, so the always-on build-time banner was replaced by the 503-driven notice (same styled banner: phone + book-a-call links, `role="status"`). No visual/branding/validation/prefill changes.
- **Dead Formspree cleanup** — removed from `.env.example`, `scripts/check-env.js`, the CI build env, `copilot-instructions.md`, the privacy policy (subprocessor list now correctly attributes contact delivery to Resend), `README.md`, `WEBSITE_MANUAL.md`, `ATBD.md`, and `HOW_TO_BUILD_FROM_SCRATCH.md`.
- **Tests** — unit / integration / BDD (Vitest + Cucumber) now mock the Resend SDK instead of Formspree's `fetch`, covering the success path (Resend called, 200), the unconfigured path (503, no send), the Resend-error path (502), honeypot, rate limiting, and validation.

### Why
Formspree required a separate account/login and added a third-party dependency for something Resend already does for us. Reusing Resend keeps email delivery on one verified domain and one provider.

## Env / deployment notes
- **Resend was already provisioned** — `RESEND_API_KEY` is already set in Vercel and CI (it powers sign-in links and invoices) and the `aetherisvision.com` sending domain is already verified. **No new env var is required.**
- `NEXT_PUBLIC_FORMSPREE_ID` is now unused and can be removed from Vercel (and the GitHub Actions secret) at your convenience — not required for this PR to work.

## Test plan
- [x] `npm run lint` — 0 errors (23 warnings, under the 24 cap)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` (Vitest) — 182 passed
- [x] `npm run test:cucumber` — 37 scenarios passed
- [x] `npm run build` — compiles and builds successfully
- [ ] Post-merge: submit a real message on `/contact` in production and confirm it lands in `contact@aetherisvision.com` with the submitter as reply-to

Made with [Cursor](https://cursor.com)