### PR TITLE
fix(blog): honest read times, chronological order, OG metadata, audience-correct CTA, RSS feed

### DIFF
--- a/src/app/blog/[slug]/opengraph-image.tsx
+++ b/src/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,73 @@
+import { ImageResponse } from "next/og";
+import { SITE } from "@/lib/constants";
+import { getPostBySlug } from "@/lib/posts";
+import { AV_MARK_DATA_URI } from "../../og-mark";
+
+// Note: edge runtime cannot be combined with generateStaticParams;
+// images render on demand at the edge, matching the other OG routes.
+export const runtime = "edge";
+export const alt = `Blog | ${SITE.name}`;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const badgeStyle = {
+  fontSize: "14px",
+  color: "#6b7280",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "999px",
+  padding: "6px 16px",
+} as const;
+
+export default async function OGImage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+  const title = post?.title ?? `Blog | ${SITE.name}`;
+  const category = post?.category ?? "Insights & Analysis";
+  const badges = post ? [post.author.name, post.date, post.readTime] : [];
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "linear-gradient(135deg, #050505 0%, #0e1726 50%, #050505 100%)",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "16px", marginBottom: "24px" }}>
+          <img src={AV_MARK_DATA_URI} width={64} height={64} alt="" />
+          <span style={{ fontSize: "18px", letterSpacing: "4px", color: "#5BA8D9", textTransform: "uppercase", fontWeight: 600 }}>
+            {SITE.name}
+          </span>
+        </div>
+        <p style={{ fontSize: "16px", letterSpacing: "3px", color: "#4b5563", textTransform: "uppercase", fontWeight: 600, margin: "0 0 16px" }}>
+          {category}
+        </p>
+        <h1
+          style={{
+            fontSize: title.length > 60 ? "44px" : "54px",
+            fontWeight: 700,
+            color: "#ffffff",
+            lineHeight: 1.15,
+            margin: 0,
+            letterSpacing: "-1px",
+            maxWidth: "1000px",
+          }}
+        >
+          {title}
+        </h1>
+        <div style={{ display: "flex", gap: "16px", marginTop: "auto" }}>
+          {badges.map((label) => (
+            <span key={label} style={badgeStyle}>{label}</span>
+          ))}
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
-import { posts, getPostBySlug, getPrevNextPosts } from "@/lib/posts";
-import { SITE } from "@/lib/constants";
+import type { Metadata } from "next";
+import { posts, getPostBySlug, getPrevNextPosts, getPostISODate } from "@/lib/posts";
+import { SITE, SAM } from "@/lib/constants";
 import { publisherRef } from "@/lib/jsonld";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
@@ -17,13 +18,31 @@ export async function generateStaticParams() {
   return posts.map((post) => ({ slug: post.slug }));
 }
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const post = getPostBySlug(slug);
   if (!post) return {};
+  const url = `${SITE.url}/blog/${post.slug}`;
   return {
     title: `${post.title} | ${SITE.name}`,
     description: post.summary,
+    alternates: { canonical: url },
+    openGraph: {
+      type: "article",
+      title: post.title,
+      description: post.summary,
+      url,
+      siteName: SITE.name,
+      locale: "en_US",
+      publishedTime: getPostISODate(post),
+      authors: [post.author.name],
+      section: post.category,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: post.title,
+      description: post.summary,
+    },
   };
 }
 
@@ -133,17 +152,17 @@ export default async function BlogPost({ params }: Props) {
           {/* CTA */}
           <div className="rounded-xl border border-white/5 bg-white/[0.02] p-8 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
             <div>
-              <p className="text-white font-medium mb-1">Have a project in mind?</p>
+              <p className="text-white font-medium mb-1">Working on a mission like this?</p>
               <p className="text-gray-500 text-sm font-light">
-                We build custom websites and web applications for Oklahoma businesses. Veteran-owned, based in Mustang, OK.
+                {SITE.name} delivers AI/ML, operational meteorology, and technical consulting for federal, defense, and commercial clients. Veteran-owned ({SAM.setAside}).
               </p>
             </div>
             <div className="flex flex-col sm:flex-row gap-3 shrink-0">
               <a
-                href="/intake"
+                href="/capabilities"
                 className="inline-flex h-10 items-center justify-center rounded-md bg-white px-6 text-sm font-medium text-black hover:bg-gray-200 transition"
               >
-                Start a Project
+                View Capabilities
               </a>
               <a
                 href="/contact"
@@ -167,7 +186,7 @@ export default async function BlogPost({ params }: Props) {
             "@type": "BlogPosting",
             headline: post.title,
             description: post.summary,
-            datePublished: post.date,
+            datePublished: getPostISODate(post),
             author: {
               "@type": "Person",
               name: post.author.name,

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { posts, getPostBySlug, getPrevNextPosts, getPostISODate } from "@/lib/posts";
+import { posts, getPostBySlug, getPrevNextPosts, getPostISODate, parsePostDate } from "@/lib/posts";
 import { SITE, SAM } from "@/lib/constants";
 import { publisherRef } from "@/lib/jsonld";
 import Navbar from "@/components/Navbar";
@@ -34,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       url,
       siteName: SITE.name,
       locale: "en_US",
-      publishedTime: getPostISODate(post),
+      publishedTime: parsePostDate(post.date).toISOString(),
       authors: [post.author.name],
       section: post.category,
     },

--- a/src/app/blog/opengraph-image.tsx
+++ b/src/app/blog/opengraph-image.tsx
@@ -1,0 +1,73 @@
+import { ImageResponse } from "next/og";
+import { SITE } from "@/lib/constants";
+import { AV_MARK_DATA_URI } from "../og-mark";
+
+export const runtime = "edge";
+export const alt = `Blog | ${SITE.name}`;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const badgeStyle = {
+  fontSize: "14px",
+  color: "#6b7280",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: "999px",
+  padding: "6px 16px",
+} as const;
+
+const badges = ["Atmospheric Modeling", "AI / ML Architecture", "Defense Contracting"];
+
+export default function OGImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "linear-gradient(135deg, #050505 0%, #0e1726 50%, #050505 100%)",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "16px", marginBottom: "24px" }}>
+          <img src={AV_MARK_DATA_URI} width={64} height={64} alt="" />
+          <span style={{ fontSize: "18px", letterSpacing: "4px", color: "#5BA8D9", textTransform: "uppercase", fontWeight: 600 }}>
+            {SITE.name}
+          </span>
+        </div>
+        <p style={{ fontSize: "16px", letterSpacing: "3px", color: "#4b5563", textTransform: "uppercase", fontWeight: 600, margin: "0 0 16px" }}>
+          Blog
+        </p>
+        <h1 style={{ fontSize: "64px", fontWeight: 700, color: "#ffffff", lineHeight: 1.1, margin: 0, letterSpacing: "-2px" }}>
+          Insights
+        </h1>
+        <h1
+          style={{
+            fontSize: "64px",
+            fontWeight: 700,
+            background: "linear-gradient(to right, #93c5fd, #6b7280)",
+            backgroundClip: "text",
+            color: "transparent",
+            lineHeight: 1.1,
+            margin: 0,
+            letterSpacing: "-2px",
+          }}
+        >
+          &amp; Analysis.
+        </h1>
+        <p style={{ fontSize: "22px", color: "#9ca3af", marginTop: "28px", maxWidth: "700px", lineHeight: 1.5 }}>
+          Executive perspectives on atmospheric modeling, machine learning architecture, and technical defense contracting.
+        </p>
+        <div style={{ display: "flex", gap: "16px", marginTop: "auto" }}>
+          {badges.map((label) => (
+            <span key={label} style={badgeStyle}>{label}</span>
+          ))}
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -34,7 +34,7 @@ export function GET(): Response {
   <channel>
     <title>${escapeXml(`${SITE.name} — Insights & Analysis`)}</title>
     <link>${SITE.url}/blog</link>
-    <description>${escapeXml("Insights on AI, meteorology, and defense consulting from Aetheris Vision.")}</description>
+    <description>${escapeXml(`Insights on AI, meteorology, and defense consulting from ${SITE.name}.`)}</description>
     <language>en-us</language>
     <lastBuildDate>${lastBuildDate}</lastBuildDate>
     <atom:link href="${SITE.url}/feed.xml" rel="self" type="application/rss+xml"/>

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,51 @@
+import { posts, parsePostDate } from "@/lib/posts";
+import { SITE } from "@/lib/constants";
+
+export const dynamic = "force-static";
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+export function GET(): Response {
+  const lastBuildDate = posts.length > 0 ? parsePostDate(posts[0].date).toUTCString() : new Date().toUTCString();
+
+  const items = posts
+    .map((post) => {
+      const url = `${SITE.url}/blog/${post.slug}`;
+      return `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <pubDate>${parsePostDate(post.date).toUTCString()}</pubDate>
+      <description>${escapeXml(post.summary)}</description>
+      <category>${escapeXml(post.category)}</category>
+    </item>`;
+    })
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(`${SITE.name} — Insights & Analysis`)}</title>
+    <link>${SITE.url}/blog</link>
+    <description>${escapeXml("Insights on AI, meteorology, and defense consulting from Aetheris Vision.")}</description>
+    <language>en-us</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${SITE.url}/feed.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>
+`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    },
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,11 @@ export const metadata: Metadata = {
   description: SITE.description,
   metadataBase: new URL(SITE.url),
   robots: { index: false, follow: false },
+  alternates: {
+    types: {
+      "application/rss+xml": `${SITE.url}/feed.xml`,
+    },
+  },
   manifest: "/manifest.json",
   icons: {
     icon: [

--- a/src/components/BlogSubscribeCard.tsx
+++ b/src/components/BlogSubscribeCard.tsx
@@ -40,10 +40,10 @@ export default function BlogSubscribeCard() {
           </form>
         ) : (
           <a
-            href="/contact?topic=Blog%20Subscription"
+            href="/feed.xml"
             className="inline-flex h-11 items-center justify-center rounded-md bg-white px-5 text-sm font-medium text-black transition-colors hover:bg-gray-200"
           >
-            Subscribe by Email
+            Subscribe via RSS
           </a>
         )}
       </div>

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -15,7 +15,35 @@ export type Post = {
   content: string
 }
 
-export const posts: Post[] = [
+const WORDS_PER_MINUTE = 200;
+
+/** Compute an honest read time from actual word count (~200 wpm, min 1 min). */
+export function computeReadTime(content: string): string {
+  const words = content.trim().split(/\s+/).filter(Boolean).length;
+  const minutes = Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+  return `${minutes} min read`;
+}
+
+/** Parse a post's display date (e.g. "Mar 26, 2026") to a UTC-midnight Date. */
+export function parsePostDate(date: string): Date {
+  const parsed = new Date(date);
+  return new Date(Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()));
+}
+
+/** ISO 8601 date (YYYY-MM-DD) for metadata, JSON-LD, and feeds. */
+export function getPostISODate(post: Pick<Post, "date">): string {
+  return parsePostDate(post.date).toISOString().slice(0, 10);
+}
+
+/** Newest first; ties broken by id descending so ordering is stable. */
+export function sortPostsByDateDesc<T extends Pick<Post, "date" | "id">>(items: readonly T[]): T[] {
+  return [...items].sort((a, b) => {
+    const diff = parsePostDate(b.date).getTime() - parsePostDate(a.date).getTime();
+    return diff !== 0 ? diff : b.id - a.id;
+  });
+}
+
+const authoredPosts: Omit<Post, "readTime">[] = [
   {
     id: 6,
     slug: "zero-trust-security-implementation",
@@ -30,7 +58,6 @@ export const posts: Post[] = [
     },
     summary:
       "Building production-grade security middleware with Content Security Policy, rate limiting, and comprehensive threat detection, demonstrated through live implementation.",
-    readTime: "12 min read",
     content: `
 Security isn't a checklist. It's an architectural philosophy that permeates every layer of your system. After 35 years in environments where security failures have lethal consequences, I've learned that **true security requires assuming breach and designing for containment.**
 
@@ -58,7 +85,6 @@ For the full technical implementation details, contact us for a complete securit
     },
     summary:
       "Real-time performance monitoring with live Core Web Vitals analysis, memory profiling, and optimization strategies that deliver measurable user experience improvements.",
-    readTime: "10 min read",
     content: `
 Performance isn't just about fast page loads. It's about **predictable, reliable systems that scale under real-world conditions**. After building systems for NASA, NOAA, and defense agencies where performance failures have mission consequences, I've learned that true performance engineering requires understanding what actually affects user experience, not just optimizing for benchmark scores.
 
@@ -85,7 +111,6 @@ For the complete performance engineering methodology, contact us for detailed co
     },
     summary:
       "How 35 years of cross-domain expertise in meteorology, AI, and federal contracting creates competitive advantages that cannot be replicated by assembling teams of specialists.",
-    readTime: "6 min read",
     content: `
 The consulting market is flooded with specialists. Meteorologists who understand atmospheric physics. AI experts who build neural networks. Federal contractors who navigate government procurement. Web developers who build digital solutions.
 
@@ -113,7 +138,6 @@ Contact us to learn how convergence creates competitive advantage for your organ
     },
     summary:
       "A strategic overview of how state and federal agencies can leverage Veteran-Owned Small Business (VOSB) statuses to streamline tech procurement and architecture advisement.",
-    readTime: "4 min read",
     content: `
 The federal procurement landscape is vast, and for agencies seeking specialized technical consulting (particularly in niche domains like atmospheric modeling, AI integration, and defense systems), knowing how to structure an acquisition is as important as knowing what to acquire.
 
@@ -138,7 +162,6 @@ Contact Aetheris Vision for acquisition strategy guidance to help agencies struc
     },
     summary:
       "How deep-learning models are transforming raw satellite data into actionable mission-critical insights faster than traditional numerical weather prediction (NWP) models.",
-    readTime: "5 min read",
     content: `
 For decades, Numerical Weather Prediction (NWP) has been the gold standard in operational meteorology. Atmospheric models like the GFS, ECMWF, and NAM have served forecasters well, but they carry a fundamental constraint: they are governed by equations of physics that require enormous computational resources and significant lead time to run.
 
@@ -153,6 +176,12 @@ For defense and government applications, the implications are profound. Aetheris
   }
 ];
 
+/** All posts, newest first, with read times computed from actual word count. */
+export const posts: Post[] = sortPostsByDateDesc(authoredPosts).map((post) => ({
+  ...post,
+  readTime: computeReadTime(post.content),
+}));
+
 export function getCategories(): string[] {
   const categories = Array.from(new Set(posts.map(post => post.category)));
   return categories.sort();
@@ -162,15 +191,19 @@ export function getPostBySlug(slug: string): Post | undefined {
   return posts.find(post => post.slug === slug);
 }
 
+/**
+ * Chronological neighbors: `prev` is the previous (older) post,
+ * `next` is the next (newer) post.
+ */
 export function getPrevNextPosts(currentSlug: string): { prev: Post | null; next: Post | null } {
   const currentIndex = posts.findIndex(post => post.slug === currentSlug);
-  
+
   if (currentIndex === -1) {
     return { prev: null, next: null };
   }
-  
+
   return {
-    prev: currentIndex > 0 ? posts[currentIndex - 1] : null,
-    next: currentIndex < posts.length - 1 ? posts[currentIndex + 1] : null
+    prev: currentIndex < posts.length - 1 ? posts[currentIndex + 1] : null,
+    next: currentIndex > 0 ? posts[currentIndex - 1] : null,
   };
 }

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -20,13 +20,17 @@ const WORDS_PER_MINUTE = 200;
 /** Compute an honest read time from actual word count (~200 wpm, min 1 min). */
 export function computeReadTime(content: string): string {
   const words = content.trim().split(/\s+/).filter(Boolean).length;
-  const minutes = Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+  // Ceil so read times are never understated for posts just past a minute boundary.
+  const minutes = Math.max(1, Math.ceil(words / WORDS_PER_MINUTE));
   return `${minutes} min read`;
 }
 
 /** Parse a post's display date (e.g. "Mar 26, 2026") to a UTC-midnight Date. */
 export function parsePostDate(date: string): Date {
   const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid post date: "${date}"`);
+  }
   return new Date(Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate()));
 }
 

--- a/tests/unit/posts.test.ts
+++ b/tests/unit/posts.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { posts, getPostBySlug, getPrevNextPosts, getCategories } from "@/lib/posts";
+import {
+  posts,
+  getPostBySlug,
+  getPrevNextPosts,
+  getCategories,
+  computeReadTime,
+  sortPostsByDateDesc,
+  parsePostDate,
+  getPostISODate,
+} from "@/lib/posts";
 
 describe("posts data", () => {
   it("exports a non-empty posts array", () => {
@@ -37,6 +46,73 @@ describe("posts data", () => {
     const ids = posts.map((p) => p.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
+
+  it("posts are sorted by date descending (newest first)", () => {
+    for (let i = 1; i < posts.length; i++) {
+      const prevTime = parsePostDate(posts[i - 1].date).getTime();
+      const currTime = parsePostDate(posts[i].date).getTime();
+      expect(prevTime).toBeGreaterThanOrEqual(currTime);
+    }
+  });
+
+  it("read times are computed from actual content word count", () => {
+    for (const post of posts) {
+      expect(post.readTime).toBe(computeReadTime(post.content));
+    }
+  });
+});
+
+describe("computeReadTime", () => {
+  it("returns a minimum of 1 min read for short content", () => {
+    expect(computeReadTime("just a few words")).toBe("1 min read");
+    expect(computeReadTime("")).toBe("1 min read");
+  });
+
+  it("computes minutes at ~200 words per minute", () => {
+    const words400 = Array.from({ length: 400 }, (_, i) => `word${i}`).join(" ");
+    expect(computeReadTime(words400)).toBe("2 min read");
+    const words1000 = Array.from({ length: 1000 }, (_, i) => `word${i}`).join(" ");
+    expect(computeReadTime(words1000)).toBe("5 min read");
+  });
+
+  it("ignores extra whitespace when counting words", () => {
+    expect(computeReadTime("  one \n\n two\t three  ")).toBe("1 min read");
+  });
+});
+
+describe("sortPostsByDateDesc", () => {
+  it("sorts newest first", () => {
+    const items = [
+      { id: 1, date: "Jan 15, 2026" },
+      { id: 2, date: "Mar 26, 2026" },
+      { id: 3, date: "Feb 28, 2026" },
+    ];
+    expect(sortPostsByDateDesc(items).map((p) => p.id)).toEqual([2, 3, 1]);
+  });
+
+  it("breaks date ties by id descending", () => {
+    const items = [
+      { id: 3, date: "Mar 25, 2026" },
+      { id: 5, date: "Mar 25, 2026" },
+    ];
+    expect(sortPostsByDateDesc(items).map((p) => p.id)).toEqual([5, 3]);
+  });
+
+  it("does not mutate the input array", () => {
+    const items = [
+      { id: 1, date: "Jan 15, 2026" },
+      { id: 2, date: "Mar 26, 2026" },
+    ];
+    sortPostsByDateDesc(items);
+    expect(items.map((p) => p.id)).toEqual([1, 2]);
+  });
+});
+
+describe("getPostISODate", () => {
+  it("formats display dates as YYYY-MM-DD", () => {
+    expect(getPostISODate({ date: "Mar 26, 2026" })).toBe("2026-03-26");
+    expect(getPostISODate({ date: "Jan 15, 2026" })).toBe("2026-01-15");
+  });
 });
 
 describe("getPostBySlug", () => {
@@ -53,18 +129,18 @@ describe("getPostBySlug", () => {
 });
 
 describe("getPrevNextPosts", () => {
-  it("returns null prev for the first post", () => {
+  it("returns null next for the newest post (nothing newer)", () => {
     const { prev, next } = getPrevNextPosts(posts[0].slug);
-    expect(prev).toBeNull();
+    expect(next).toBeNull();
     if (posts.length > 1) {
-      expect(next).not.toBeNull();
+      expect(prev).not.toBeNull();
     }
   });
 
-  it("returns null next for the last post", () => {
-    const last = posts[posts.length - 1];
-    const { next } = getPrevNextPosts(last.slug);
-    expect(next).toBeNull();
+  it("returns null prev for the oldest post (nothing older)", () => {
+    const oldest = posts[posts.length - 1];
+    const { prev } = getPrevNextPosts(oldest.slug);
+    expect(prev).toBeNull();
   });
 
   it("returns both prev and next for a middle post", () => {
@@ -74,6 +150,28 @@ describe("getPrevNextPosts", () => {
       expect(prev).not.toBeNull();
       expect(next).not.toBeNull();
     }
+  });
+
+  it("navigation follows chronological order", () => {
+    for (let i = 0; i < posts.length; i++) {
+      const { prev, next } = getPrevNextPosts(posts[i].slug);
+      if (prev) {
+        expect(parsePostDate(prev.date).getTime()).toBeLessThanOrEqual(
+          parsePostDate(posts[i].date).getTime()
+        );
+      }
+      if (next) {
+        expect(parsePostDate(next.date).getTime()).toBeGreaterThanOrEqual(
+          parsePostDate(posts[i].date).getTime()
+        );
+      }
+    }
+  });
+
+  it("returns nulls for an unknown slug", () => {
+    const { prev, next } = getPrevNextPosts("nonexistent-post-slug-xyz");
+    expect(prev).toBeNull();
+    expect(next).toBeNull();
   });
 });
 

--- a/tests/unit/posts.test.ts
+++ b/tests/unit/posts.test.ts
@@ -75,6 +75,11 @@ describe("computeReadTime", () => {
     expect(computeReadTime(words1000)).toBe("5 min read");
   });
 
+  it("rounds up so read times are never understated", () => {
+    const words201 = Array.from({ length: 201 }, (_, i) => `word${i}`).join(" ");
+    expect(computeReadTime(words201)).toBe("2 min read");
+  });
+
   it("ignores extra whitespace when counting words", () => {
     expect(computeReadTime("  one \n\n two\t three  ")).toBe("1 min read");
   });
@@ -112,6 +117,12 @@ describe("getPostISODate", () => {
   it("formats display dates as YYYY-MM-DD", () => {
     expect(getPostISODate({ date: "Mar 26, 2026" })).toBe("2026-03-26");
     expect(getPostISODate({ date: "Jan 15, 2026" })).toBe("2026-01-15");
+  });
+});
+
+describe("parsePostDate", () => {
+  it("throws a clear error for malformed dates", () => {
+    expect(() => parsePostDate("not a date")).toThrowError(/Invalid post date/);
   });
 });
 

--- a/tests/unit/rss-feed.test.ts
+++ b/tests/unit/rss-feed.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { GET } from "@/app/feed.xml/route";
+import { posts } from "@/lib/posts";
+import { SITE } from "@/lib/constants";
+
+describe("RSS feed (/feed.xml)", () => {
+  it("responds with an RSS content type", () => {
+    const res = GET();
+    expect(res.headers.get("Content-Type")).toContain("application/rss+xml");
+  });
+
+  it("is a valid RSS 2.0 document with a channel", async () => {
+    const xml = await GET().text();
+    expect(xml).toContain('<rss version="2.0"');
+    expect(xml).toContain("<channel>");
+    expect(xml).toContain(`<link>${SITE.url}/blog</link>`);
+  });
+
+  it("includes one item per post with title, link, pubDate, and description", async () => {
+    const xml = await GET().text();
+    expect(xml.match(/<item>/g)?.length).toBe(posts.length);
+    for (const post of posts) {
+      expect(xml).toContain(`<link>${SITE.url}/blog/${post.slug}</link>`);
+    }
+    expect(xml.match(/<pubDate>/g)?.length).toBe(posts.length);
+    expect(xml.match(/<description>/g)?.length).toBe(posts.length + 1); // items + channel
+  });
+
+  it("escapes XML special characters in titles", async () => {
+    const xml = await GET().text();
+    // No raw unescaped ampersands outside entities
+    expect(xml).not.toMatch(/&(?!amp;|lt;|gt;|quot;|apos;)/);
+  });
+
+  it("uses parseable RFC 822 pubDates", async () => {
+    const xml = await GET().text();
+    const pubDates = [...xml.matchAll(/<pubDate>(.*?)<\/pubDate>/g)].map((m) => m[1]);
+    for (const d of pubDates) {
+      expect(Number.isNaN(new Date(d).getTime())).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the technical fixes approved from the read-only blog audit (no long-form content changes).

| Audit finding | Fix |
|---|---|
| Stored read times wildly overstate actual length (e.g. "12 min read" on ~160 words) | `computeReadTime()` in `src/lib/posts.ts` derives read time from actual word count (~200 wpm, min "1 min read"); applied to all posts at module load so future posts stay honest automatically |
| Blog index renders array order, not chronological (Jan 15 above Feb 28); prev/next nav follows the same order | `posts` export is now sorted date-descending (ties broken by id) via `sortPostsByDateDesc()`; `getPrevNextPosts()` is chronological — `prev` = older post, `next` = newer post. Featured-post logic in `BlogClientPage` unchanged |
| `generateMetadata` for posts only set title/description; no OG image for blog routes | Added `openGraph` (type `article`, url, `publishedTime`, author, section), `twitter` card, and canonical to post metadata. New `opengraph-image.tsx` for `/blog` (static) and `/blog/[slug]` (dynamic per-post title/category/byline), mirroring the existing `/about` etc. routes and `og-mark.ts` brand mark |
| Post-page CTA pitched "custom websites for Oklahoma businesses" — clashes with federal/defense/AI content | CTA rewritten for the actual audience (AI/ML, operational meteorology, technical consulting for federal/defense and commercial clients), sourced from `SITE`/`SAM` constants; links to `/capabilities` and `/contact`. Visual styling unchanged |
| No RSS feed; Subscribe card fell back to the contact page | New RSS 2.0 feed at `/feed.xml` (`src/app/feed.xml/route.ts`) with title/link/guid/pubDate/description per post and XML escaping. Root layout advertises it via `alternates.types`. Subscribe card fallback now points at `/feed.xml` (env-var form override behavior unchanged) |

Also: JSON-LD `datePublished` now uses ISO 8601 (`getPostISODate`) instead of the display date string.

## Test plan

- [x] `npm run lint` — 0 errors (23 pre-existing warnings)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 21 files / 199 tests pass, including new tests for `computeReadTime`, `sortPostsByDateDesc`, chronological `posts` ordering, `getPrevNextPosts` semantics, `getPostISODate`, and RSS feed validity (content type, item count, escaping, parseable pubDates)
- [x] `next build` — passes locally (with placeholder secrets; full-secret build runs in Vercel CI)
- [ ] Verify Vercel preview: `/blog` ordering, `/feed.xml`, OG images for `/blog` and a post

## Notes

- Per-slug OG image cannot combine `runtime = "edge"` with `generateStaticParams` (Next.js build error), so it renders on demand at the edge like the other OG routes.
- Date tie between the two Mar 25 posts is broken by id descending for deterministic ordering.

Made with [Cursor](https://cursor.com)