### PR TITLE
fix(copy): site-wide proofread — typo, usage error, awkward SLA phrasing

### DIFF
--- a/src/app/security-status/page.tsx
+++ b/src/app/security-status/page.tsx
@@ -26,7 +26,7 @@ export default function SecurityStatusPage() {
           </div>
           
           <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-semibent mb-2">Rate Limiting</h3>
+            <h3 className="text-lg font-semibold mb-2">Rate Limiting</h3>
             <div className="text-3xl font-bold text-blue-400">Active</div>
             <p className="text-sm text-gray-400">100 req/15min</p>
           </div>

--- a/src/app/security/page.tsx
+++ b/src/app/security/page.tsx
@@ -297,7 +297,7 @@ export default function SecurityPage() {
               <h3 className="text-2xl font-semibold text-white mb-4">Enterprise Security Questions?</h3>
               <p className="text-gray-400 mb-6 max-w-2xl mx-auto">
                 Our security team can provide detailed compliance documentation, conduct security assessments, 
-                and answer specific enterprise requirements during your consultation.
+                and address specific enterprise requirements during your consultation.
               </p>
               <a
                 href="/contact"

--- a/src/lib/portfolio-data.ts
+++ b/src/lib/portfolio-data.ts
@@ -144,7 +144,7 @@ export const sla = [
   { label: "Staging environment access", value: "10-14 business days" },
   { label: "Production deployment", value: "15-21 business days" },
   { label: "Quality assurance period", value: "30 days comprehensive warranty" },
-  { label: "Priority support response", value: "4 hours business days / 8 hours weekends" },
+  { label: "Priority support response", value: "4 hours on business days / 8 hours on weekends" },
   { label: "Performance guarantee", value: "Lighthouse 90+ or full refund" },
 ];
 


### PR DESCRIPTION
## Summary

Full proofread sweep of all user-facing text, hunting (1) JSX whitespace-swallowing bugs of the class fixed in #67 ("book a calland we'll") and (2) objective grammar/typo errors. Scope covered: every `src/app/**/page.tsx` (including all 11 portfolio demo sites), layouts, all `src/components/**`, `constants.ts`, `posts.ts` post bodies, `chat-context.ts`, `portfolio-data.ts`, error/empty states, form validation messages, all Resend email templates (contact, intake, magic-link, reviews, invoices, DocuSeal webhooks), metadata descriptions, the privacy policy, `opengraph-image`, and `feed.xml`.

## Errors found & fixed

| File | Before | After |
|---|---|---|
| `src/app/security-status/page.tsx` | `font-semibent` (broken Tailwind class — "Rate Limiting" heading rendered without semibold weight) | `font-semibold` |
| `src/app/security/page.tsx` | "…conduct security assessments, and **answer** specific enterprise requirements" | "…and **address** specific enterprise requirements" |
| `src/lib/portfolio-data.ts` (renders on `/portfolio` and `/capabilities` SLA tables) | "4 hours business days / 8 hours weekends" | "4 hours **on** business days / 8 hours **on** weekends" |

## Missing-space (text-jam) audit — result: clean

Systematically checked, via multiline regex sweeps **and** file-by-file reading:
- text↔inline-element boundaries (`<a>`/`<Link>`/`<strong>`/`<span>`) across line breaks without `{" "}`
- conditional renders / ternaries abutting text
- template-literal and string concatenations
- missing space after `,`/`.` inside prose strings

No jams found beyond the one already fixed in #67. The portfolio demo banners all correctly use explicit `{" "}` separators.

## Suspicious items intentionally NOT changed

- **`/intake` claims "5 quick fields"** while the form has 7 sections — factual/messaging inconsistency, not a grammar bug; flagging for a separate decision.
- **"18 years experience"** (healthcare demo, law-firm demo) — strictly "years' experience," but it's consistent fictional-demo marketing copy; left as-is.
- **`✦ DEMO SITE, built by …`** comma style — consistent across all 11 demos; deliberate voice.
- **Tagline variations** between `SITE.tagline` / `ogDescription` / chat prompt — deliberate messaging differences, not errors.
- **No permanent textContent-jam test added**: the bug class produces lowercase-lowercase jams ("calland") that a regex can't catch without a dictionary; any low-noise version would also be too weak to catch real regressions. Throwaway grep sweeps were used instead.

## Quality gates

- `eslint src/` — 0 errors (23 pre-existing warnings, untouched files)
- `tsc --noEmit` — clean
- `vitest run` — 201/201 passing
- `next build` — succeeds (with placeholder `DATABASE_URL`/`RESEND_API_KEY` locally; real values exist in Vercel)

Per repo CICD rules: **do not merge** until Copilot review comments are triaged.

Made with [Cursor](https://cursor.com)