### PR TITLE
fix(copy): correct aetheris etymology and missing space on home/about

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -153,7 +153,7 @@ export default function AboutPage() {
                   The Meaning Behind <span className="text-transparent bg-clip-text bg-gradient-to-r from-gray-200 to-gray-500">Aetheris</span>
                 </h2>
                 <p className="text-gray-400 font-light leading-relaxed mb-4">
-                  Derived from the ancient Latin and Greek word <em className="text-white">aetheris</em> (meaning &ldquo;the clear sky&rdquo; or &ldquo;the pure, fresh air breathed by the gods&rdquo;), our name reflects a commitment to mapping the unknown with clarity and precision.
+                  Derived from <em className="text-white">aetheris</em>, a form of the Latin <em className="text-white">aether</em>{' '}(from the Greek <em className="text-white">aith&#275;r</em>, the bright upper air of the heavens, the pure air breathed by the gods), our name reflects a commitment to mapping the unknown with clarity and precision.
                 </p>
                 <p className="text-gray-400 font-light leading-relaxed">
                   In ancient philosophy, aether was the fifth element filling the universe above the terrestrial sphere. For us, it represents the convergence of 35 years of deep operational expertise with a vision for the future: bringing structure, clarity, and advanced AI/ML capabilities to the systems that chart the skies, space, and earth.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -125,7 +125,7 @@ export default async function Home() {
               
               <FadeIn delay={0.15}>
                 <p className="text-lg md:text-xl text-gray-300 font-light leading-relaxed mb-6">
-                  Derived from the ancient Latin and Greek word <span className="text-white italic">aetheris</span> (meaning &quot;the clear sky&quot; or &quot;the pure, fresh air breathed by the gods&quot;), our name reflects a profound commitment to mapping the unknown.
+                  Derived from <span className="text-white italic">aetheris</span>, a form of the Latin <span className="text-white italic">aether</span>{' '}(from the Greek <span className="text-white italic">aith&#275;r</span>, the bright upper air of the heavens, the pure air breathed by the gods), our name reflects a profound commitment to mapping the unknown.
                 </p>
               </FadeIn>
               


### PR DESCRIPTION
## Summary
- Fixes the jammed space spotted on the live site: "aetheris(meaning ..." on the homepage "The Aetheris Vision" section and the About page "Our Name" card.
- Corrects the etymology while keeping the original imagery and sentence endings. New copy: "Derived from *aetheris*, a form of the Latin *aether* (from the Greek *aithēr*, the bright upper air of the heavens, the pure air breathed by the gods), our name reflects a profound commitment to mapping the unknown." (About page keeps its "...with clarity and precision." ending.)
- Uses an explicit `{' '}` before the parenthetical so JSX whitespace handling cannot drop the space again (the previous source had a literal space, yet the production HTML rendered without it).

## Test plan
- [x] `npm run lint` — 0 errors (23 pre-existing warnings)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 201/201 passing
- [x] Rendered both pages locally and verified the sentence renders with correct spacing
- [ ] Verify Vercel production deploy after merge

Made with [Cursor](https://cursor.com)