### PR TITLE
fix(routing): redirect bare /services to /services/web (404 fix)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -36,6 +36,17 @@ const nextConfig: NextConfig = {
     dangerouslyAllowSVG: false,
   },
   
+  async redirects() {
+    return [
+      // /services has no index page — send visitors to the web services page
+      {
+        source: "/services",
+        destination: "/services/web",
+        permanent: true,
+      },
+    ];
+  },
+
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- A design audit flagged a 404 around the navbar "Services" link. Investigation showed the link itself targets `/services/web`, which exists and serves 200 — the actual 404 is the bare `/services` parent path, which has no index route (audit crawlers probe ancestor paths, and users truncate URLs).
- Fix: add a permanent redirect `/services` → `/services/web` in `next.config.ts`. No new page scaffolded; nav/footer links unchanged since they already point at a live page ("Capabilities" is a separate, working nav item).

## Verification
- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean
- `npm test` — 201/201 passing
- Live before fix: `curl -s -o /dev/null -w "%{http_code}" https://aetherisvision.com/services` → 404; `/services/web` → 200

## Test plan
- [ ] After deploy: `curl -sI https://aetherisvision.com/services` returns 308 → `/services/web`
- [ ] `/services/web` still 200

Made with [Cursor](https://cursor.com)