### PR TITLE
feat(og-demo): before/after comparison panel via compare_uri

### DIFF
--- a/src/app/admin/omni-gridder/page.tsx
+++ b/src/app/admin/omni-gridder/page.tsx
@@ -100,6 +100,10 @@ export default function OmniGridderDemoPage() {
   const [globalError, setGlobalError] = useState<string | null>(null)
   const [workerTriggered, setWorkerTriggered] = useState<boolean | null>(null)
   const pollTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+  // Input URI from the last submit response — passed back on the chainPlot
+  // poll so the server can chain a before/after plot (server re-validates
+  // it against its own allowlist; this is display plumbing, not authority).
+  const inputUriRef = useRef<string>('')
 
   const log = useCallback((label: string) => {
     setTimeline((prev) => [...prev, { at: Date.now(), label }])
@@ -131,7 +135,9 @@ export default function OmniGridderDemoPage() {
   ): Promise<void> {
     let res: Response
     try {
-      const qs = chainPlot ? '?chainPlot=1' : ''
+      const qs = chainPlot
+        ? `?chainPlot=1${inputUriRef.current ? `&compare=${encodeURIComponent(inputUriRef.current)}` : ''}`
+        : ''
       res = await fetch(`/api/admin/omni-gridder/status/${jobId}${qs}`)
     } catch {
       log(`Network error polling ${jobId} — retrying`)
@@ -258,8 +264,10 @@ export default function OmniGridderDemoPage() {
 
       const data = (await res.json()) as {
         jobs: { jobId: string; method: RegridMethod }[]
+        inputUri: string
         workerTriggered: boolean
       }
+      inputUriRef.current = data.inputUri ?? ''
       setWorkerTriggered(data.workerTriggered)
       if (!data.workerTriggered) {
         log('Worker auto-trigger unavailable — jobs stay queued until og-worker is run manually')

--- a/src/app/api/admin/omni-gridder/status/[jobId]/route.ts
+++ b/src/app/api/admin/omni-gridder/status/[jobId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 import { getJobStatus, submitJob } from '@/lib/omni-gridder-client'
+import { allowedInputUris } from '@/lib/og-demo-inputs'
 
 const GCS_STAGING_BUCKET = process.env.OG_GCS_STAGING_BUCKET
 const PLOT_SUFFIX = '-plot'
@@ -38,6 +39,12 @@ export async function GET(
   // URI to read via DataReader, not a browser-facing signed download link.
   const isRegridJob = status.processor_type === 'regrid' && !jobId.endsWith(PLOT_SUFFIX)
   if (chainPlot && isRegridJob && status.status === 'succeeded') {
+    // Optional before/after panel: the client passes back the input URI it
+    // was told at submit time (?compare=...); it is only honored if it's in
+    // the same server-side allowlist the submit route enforces — the plot
+    // worker reads this URI from GCS, so it must never be client-arbitrary.
+    const compare = request.nextUrl.searchParams.get('compare')
+    const compareUri = compare && allowedInputUris().includes(compare) ? compare : undefined
     const plotJobId = `${jobId}${PLOT_SUFFIX}`
     await submitJob({
       job_id: plotJobId,
@@ -49,6 +56,7 @@ export async function GET(
         variable: 'HGT',
         title: 'Agentic OG — Method Comparison Demo',
         colormap: 'RdYlBu_r',
+        ...(compareUri ? { compare_uri: compareUri } : {}),
       },
     })
     return NextResponse.json({ ...status, nextJobId: plotJobId })

--- a/src/app/api/admin/omni-gridder/submit/route.ts
+++ b/src/app/api/admin/omni-gridder/submit/route.ts
@@ -5,24 +5,7 @@ import { rateLimit } from '@/lib/rate-limit'
 
 const GCS_STAGING_BUCKET = process.env.OG_GCS_STAGING_BUCKET
 
-// Server-side allowlist of demo input URIs — never accept an arbitrary
-// client-supplied gs:// URI here (SSRF / cross-tenant data exposure via
-// og-server reading whatever bucket/object we hand it). First entry is the
-// default when the client doesn't specify one. Configure via
-// OG_DEMO_INPUT_URIS="gs://bucket/a.nc,gs://bucket/b.nc" in Vercel env.
-const DEFAULT_DEMO_INPUT_URIS = [
-  'gs://esmai-dev-esmai-objects/demo/hgt500_2026070706_f006.nc',
-]
-
-function allowedInputUris(): string[] {
-  const raw = process.env.OG_DEMO_INPUT_URIS
-  if (!raw) return DEFAULT_DEMO_INPUT_URIS
-  const uris = raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-  return uris.length > 0 ? uris : DEFAULT_DEMO_INPUT_URIS
-}
+import { allowedInputUris } from '@/lib/og-demo-inputs'
 
 // 0.5° CONUS grid, generated server-side (never client-supplied — same SSRF/
 // resource-exhaustion reasoning as the input allowlist above: an arbitrary

--- a/src/app/api/admin/omni-gridder/submit/route.ts
+++ b/src/app/api/admin/omni-gridder/submit/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
+import { allowedInputUris } from '@/lib/og-demo-inputs'
 import { submitJob, triggerWorkerRun } from '@/lib/omni-gridder-client'
 import { rateLimit } from '@/lib/rate-limit'
 
 const GCS_STAGING_BUCKET = process.env.OG_GCS_STAGING_BUCKET
-
-import { allowedInputUris } from '@/lib/og-demo-inputs'
 
 // 0.5° CONUS grid, generated server-side (never client-supplied — same SSRF/
 // resource-exhaustion reasoning as the input allowlist above: an arbitrary

--- a/src/lib/og-demo-inputs.ts
+++ b/src/lib/og-demo-inputs.ts
@@ -1,0 +1,19 @@
+// Server-side allowlist of omni-gridder demo input URIs — shared by the
+// submit route (choosing the regrid input) and the status route (validating
+// the compare_uri passed back for the before/after plot panel). Never accept
+// an arbitrary client-supplied gs:// URI (SSRF / cross-tenant data exposure
+// via og-server reading whatever bucket/object we hand it). First entry is
+// the default. Configure via OG_DEMO_INPUT_URIS="gs://b/a.nc,gs://b/b.nc".
+export const DEFAULT_DEMO_INPUT_URIS = [
+  'gs://esmai-dev-esmai-objects/demo/hgt500_2026070706_f006.nc',
+]
+
+export function allowedInputUris(): string[] {
+  const raw = process.env.OG_DEMO_INPUT_URIS
+  if (!raw) return DEFAULT_DEMO_INPUT_URIS
+  const uris = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  return uris.length > 0 ? uris : DEFAULT_DEMO_INPUT_URIS
+}

--- a/tests/integration/omni-gridder-api.test.ts
+++ b/tests/integration/omni-gridder-api.test.ts
@@ -218,4 +218,42 @@ describe("GET /api/admin/omni-gridder/status/[jobId] — chainPlot gating", () =
     expect(res.status).toBe(200);
     expect(submitJobMock).not.toHaveBeenCalled();
   });
+
+  it("passes an allowlisted ?compare= URI through as the plot job's compare_uri", async () => {
+    getJobStatusMock.mockResolvedValue(baseStatus);
+    const { GET } = await importStatusRoute();
+
+    // First entry of the default server-side allowlist (OG_DEMO_INPUT_URIS unset).
+    const allowed = "gs://esmai-dev-esmai-objects/demo/hgt500_2026070706_f006.nc";
+    const req = new NextRequest(
+      `http://localhost/api/admin/omni-gridder/status/${baseStatus.job_id}?chainPlot=1&compare=${encodeURIComponent(allowed)}`,
+      { headers: adminHeaders("1.1.2.4") },
+    );
+    const res = await GET(req, { params: Promise.resolve({ jobId: baseStatus.job_id }) });
+    expect(res.status).toBe(200);
+
+    expect(submitJobMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        processor_type: "plot",
+        params: expect.objectContaining({ compare_uri: allowed }),
+      }),
+    );
+  });
+
+  it("drops a non-allowlisted ?compare= URI instead of forwarding it to the worker", async () => {
+    getJobStatusMock.mockResolvedValue(baseStatus);
+    const { GET } = await importStatusRoute();
+
+    const req = new NextRequest(
+      `http://localhost/api/admin/omni-gridder/status/${baseStatus.job_id}?chainPlot=1&compare=${encodeURIComponent("gs://attacker-bucket/secret.nc")}`,
+      { headers: adminHeaders("1.1.2.5") },
+    );
+    const res = await GET(req, { params: Promise.resolve({ jobId: baseStatus.job_id }) });
+    expect(res.status).toBe(200);
+
+    // Plot still chains — but without any compare_uri param.
+    expect(submitJobMock).toHaveBeenCalledTimes(1);
+    const params = submitJobMock.mock.calls[0][0].params as Record<string, unknown>;
+    expect(params.compare_uri).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
The chained plot job now passes the demo's input URI as `params.compare_uri` — with the worker's new `--compare` renderer (omni-gridder#61), the demo map becomes a **before/after panel**: 0.25° input vs 0.5° regridded output, shared color scale, titles derived from the actual grids.

Security: the URI travels client→server for display plumbing only; the status route re-validates it against the same server-side allowlist the submit route enforces (helper moved to `src/lib/og-demo-inputs.ts`, shared by both). Never client-arbitrary.

## Test plan
- tsc clean; omni-gridder integration tests green
- Live verification after the og-worker image redeploy completes (in progress): run the demo, confirm the two-panel plot renders centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)