### PR TITLE
feat(og-demo): Download PNG button via admin-gated streaming proxy

### DIFF
--- a/src/app/admin/omni-gridder/page.tsx
+++ b/src/app/admin/omni-gridder/page.tsx
@@ -461,10 +461,18 @@ export default function OmniGridderDemoPage() {
                 alt="Regridded 500mb height field from this demo run"
                 className="w-full max-w-xl rounded-lg border border-white/10"
               />
-              <p className="mt-3 text-xs text-gray-500">
-                This link is a short-lived signed URL (15-minute TTL) — reload the page and run
-                again if it expires.
-              </p>
+              <div className="mt-3 flex items-center gap-4">
+                <a
+                  href={`/api/admin/omni-gridder/download?url=${encodeURIComponent(plotUrl)}`}
+                  className="inline-block rounded-md border border-white/20 bg-white/5 px-3 py-1.5 text-xs font-medium text-gray-200 hover:bg-white/10"
+                >
+                  Download PNG
+                </a>
+                <p className="text-xs text-gray-500">
+                  Rendered from a short-lived signed URL (15-minute TTL) — reload and run again if
+                  it expires.
+                </p>
+              </div>
             </div>
           )}
         </div>

--- a/src/app/admin/omni-gridder/page.tsx
+++ b/src/app/admin/omni-gridder/page.tsx
@@ -97,6 +97,7 @@ export default function OmniGridderDemoPage() {
   const [activeMethods, setActiveMethods] = useState<RegridMethod[]>([])
   const [timeline, setTimeline] = useState<TimelineEntry[]>([])
   const [plotUrl, setPlotUrl] = useState<string | null>(null)
+  const [plotJobId, setPlotJobId] = useState<string | null>(null)
   const [globalError, setGlobalError] = useState<string | null>(null)
   const [workerTriggered, setWorkerTriggered] = useState<boolean | null>(null)
   const pollTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
@@ -205,6 +206,7 @@ export default function OmniGridderDemoPage() {
       })
       if (data.nextJobId) {
         log(`Chained plot job ${data.nextJobId} (from ${method})`)
+        setPlotJobId(data.nextJobId)
         pollTimers.current.set(
           data.nextJobId,
           setTimeout(() => pollJob(data.nextJobId!, method, false, true, null), POLL_INTERVAL_MS),
@@ -227,6 +229,7 @@ export default function OmniGridderDemoPage() {
       stopAllPolling()
       setGlobalError(null)
       setPlotUrl(null)
+      setPlotJobId(null)
       setTimeline([])
       setWorkerTriggered(null)
       setActiveMethods(methods)
@@ -462,12 +465,14 @@ export default function OmniGridderDemoPage() {
                 className="w-full max-w-xl rounded-lg border border-white/10"
               />
               <div className="mt-3 flex items-center gap-4">
-                <a
-                  href={`/api/admin/omni-gridder/download?url=${encodeURIComponent(plotUrl)}`}
-                  className="inline-block rounded-md border border-white/20 bg-white/5 px-3 py-1.5 text-xs font-medium text-gray-200 hover:bg-white/10"
-                >
-                  Download PNG
-                </a>
+                {plotJobId && (
+                  <a
+                    href={`/api/admin/omni-gridder/download?job=${encodeURIComponent(plotJobId)}`}
+                    className="inline-block rounded-md border border-white/20 bg-white/5 px-3 py-1.5 text-xs font-medium text-gray-200 hover:bg-white/10"
+                  >
+                    Download PNG
+                  </a>
+                )}
                 <p className="text-xs text-gray-500">
                   Rendered from a short-lived signed URL (15-minute TTL) — reload and run again if
                   it expires.

--- a/src/app/api/admin/omni-gridder/download/route.ts
+++ b/src/app/api/admin/omni-gridder/download/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
+
+const GCS_STAGING_BUCKET = process.env.OG_GCS_STAGING_BUCKET
+
+// Streams a rendered plot back with attachment headers so the browser
+// downloads it instead of navigating. A plain <a download> can't do this:
+// the signed URL is cross-origin (storage.googleapis.com), where the
+// download attribute is ignored, and the bucket serves no CORS headers for
+// a client-side blob fetch. Fetching server-side sidesteps both.
+//
+// SSRF guard: only signed HTTPS URLs for objects in OUR staging bucket are
+// fetched — host and path prefix are validated before any request leaves.
+export async function GET(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+  if (!GCS_STAGING_BUCKET) {
+    return NextResponse.json({ error: 'OG_GCS_STAGING_BUCKET is not set' }, { status: 500 })
+  }
+
+  const raw = request.nextUrl.searchParams.get('url')
+  if (!raw) {
+    return NextResponse.json({ error: 'url query param required' }, { status: 400 })
+  }
+
+  let target: URL
+  try {
+    target = new URL(raw)
+  } catch {
+    return NextResponse.json({ error: 'invalid url' }, { status: 400 })
+  }
+  const validHost = target.hostname === 'storage.googleapis.com'
+  const validPath = target.pathname.startsWith(`/${GCS_STAGING_BUCKET}/`)
+  if (target.protocol !== 'https:' || !validHost || !validPath) {
+    return NextResponse.json(
+      { error: 'url must be a signed storage.googleapis.com link for the demo bucket' },
+      { status: 400 },
+    )
+  }
+
+  const upstream = await fetch(target.toString())
+  if (!upstream.ok || !upstream.body) {
+    return NextResponse.json(
+      { error: `upstream fetch failed (${upstream.status}) — the signed URL may have expired; re-run the job` },
+      { status: 502 },
+    )
+  }
+
+  const stamp = new Date().toISOString().slice(0, 16).replace(/[:T]/g, '-')
+  return new NextResponse(upstream.body, {
+    headers: {
+      'Content-Type': upstream.headers.get('content-type') ?? 'image/png',
+      'Content-Disposition': `attachment; filename="og-method-comparison-${stamp}.png"`,
+      'Cache-Control': 'no-store',
+    },
+  })
+}

--- a/src/app/api/admin/omni-gridder/download/route.ts
+++ b/src/app/api/admin/omni-gridder/download/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
+import { getJobStatus } from '@/lib/omni-gridder-client'
 
 const GCS_STAGING_BUCKET = process.env.OG_GCS_STAGING_BUCKET
+
+// Job IDs are our own generated strings (see submit/route.ts and
+// status/[jobId]/route.ts), always lowercase-alnum-hyphen and always ending
+// in "-plot" for the chained plot job this route serves. Reject anything
+// else before it ever reaches getJobStatus.
+const PLOT_JOB_ID_RE = /^[a-z][a-z0-9-]{0,62}-plot$/
 
 // Streams a rendered plot back with attachment headers so the browser
 // downloads it instead of navigating. A plain <a download> can't do this:
@@ -9,35 +16,75 @@ const GCS_STAGING_BUCKET = process.env.OG_GCS_STAGING_BUCKET
 // download attribute is ignored, and the bucket serves no CORS headers for
 // a client-side blob fetch. Fetching server-side sidesteps both.
 //
-// SSRF guard: only signed HTTPS URLs for objects in OUR staging bucket are
-// fetched — host and path prefix are validated before any request leaves.
+// Looked up by job id, not by URL: the client never sees or holds the
+// signed bearer URL in a query string. We resolve job -> status -> result_uri
+// ourselves via getJobStatus() (the same og-server client the status route
+// uses), and only THEN apply the host/path allowlist below — as defense in
+// depth, not as the primary authority (og-server is the only thing that
+// ever produces a value here, and it only ever returns signed URLs).
 export async function GET(request: NextRequest) {
   if (!isAdmin(request)) return unauthorizedResponse()
   if (!GCS_STAGING_BUCKET) {
     return NextResponse.json({ error: 'OG_GCS_STAGING_BUCKET is not set' }, { status: 500 })
   }
 
-  const raw = request.nextUrl.searchParams.get('url')
-  if (!raw) {
-    return NextResponse.json({ error: 'url query param required' }, { status: 400 })
+  const jobId = request.nextUrl.searchParams.get('job')
+  if (!jobId || !PLOT_JOB_ID_RE.test(jobId)) {
+    return NextResponse.json(
+      { error: 'job query param required — must be a plot job id ending in "-plot"' },
+      { status: 400 },
+    )
+  }
+
+  let status
+  try {
+    status = await getJobStatus(jobId)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: `Job lookup failed: ${message}` }, { status: 502 })
+  }
+  if (!status) {
+    return NextResponse.json({ error: 'Job not found' }, { status: 404 })
+  }
+  if (status.status !== 'succeeded' || !status.result_uri) {
+    return NextResponse.json(
+      { error: `Job is not ready for download (status: ${status.status})` },
+      { status: 409 },
+    )
   }
 
   let target: URL
   try {
-    target = new URL(raw)
+    target = new URL(status.result_uri)
   } catch {
-    return NextResponse.json({ error: 'invalid url' }, { status: 400 })
+    return NextResponse.json({ error: 'og-server returned an invalid result URL' }, { status: 502 })
   }
   const validHost = target.hostname === 'storage.googleapis.com'
   const validPath = target.pathname.startsWith(`/${GCS_STAGING_BUCKET}/`)
   if (target.protocol !== 'https:' || !validHost || !validPath) {
     return NextResponse.json(
-      { error: 'url must be a signed storage.googleapis.com link for the demo bucket' },
+      { error: 'result URL must be a signed storage.googleapis.com link for the demo bucket' },
       { status: 400 },
     )
   }
 
-  const upstream = await fetch(target.toString())
+  let upstream: Response
+  try {
+    upstream = await fetch(target.toString(), {
+      // A redirect off the allowlisted host must fail outright, never be
+      // followed — 'follow' would let a compromised/misconfigured upstream
+      // hop us to an arbitrary origin after the guard above already passed.
+      redirect: 'error',
+      signal: AbortSignal.timeout(20_000),
+    })
+  } catch (err) {
+    // fetch() throws (doesn't resolve to a non-ok Response) on DNS failure,
+    // network errors, timeout, and a blocked redirect — all of those must
+    // come back as JSON, not surface as Next's HTML 500 page.
+    const message = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ error: `Upstream fetch failed: ${message}` }, { status: 502 })
+  }
+
   if (!upstream.ok || !upstream.body) {
     return NextResponse.json(
       { error: `upstream fetch failed (${upstream.status}) — the signed URL may have expired; re-run the job` },

--- a/tests/integration/omni-gridder-api.test.ts
+++ b/tests/integration/omni-gridder-api.test.ts
@@ -257,3 +257,115 @@ describe("GET /api/admin/omni-gridder/status/[jobId] — chainPlot gating", () =
     expect(params.compare_uri).toBeUndefined();
   });
 });
+
+describe("GET /api/admin/omni-gridder/download", () => {
+  const PLOT_JOB_ID = "demo-1a2b3c-4d5e6f-bilinear-plot";
+  const SIGNED_URL = `https://storage.googleapis.com/${TEST_BUCKET}/demo/regrid/demo-1a2b3c-4d5e6f-bilinear/plot.png?X-Goog-Signature=abc`;
+
+  async function importDownloadRoute() {
+    return import("@/app/api/admin/omni-gridder/download/route");
+  }
+
+  function makeDownloadRequest(job: string | null, ip: string): NextRequest {
+    const url = new URL("http://localhost/api/admin/omni-gridder/download");
+    if (job !== null) url.searchParams.set("job", job);
+    return new NextRequest(url, { headers: adminHeaders(ip) });
+  }
+
+  it("rejects a malformed job id with 400 and never calls og-server", async () => {
+    const { GET } = await importDownloadRoute();
+    const res = await GET(makeDownloadRequest("not-a-plot-job", "1.1.3.1"));
+    expect(res.status).toBe(400);
+    expect(getJobStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing job param with 400", async () => {
+    const { GET } = await importDownloadRoute();
+    const res = await GET(makeDownloadRequest(null, "1.1.3.2"));
+    expect(res.status).toBe(400);
+    expect(getJobStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 for a job that has not succeeded yet", async () => {
+    getJobStatusMock.mockResolvedValue({
+      job_id: PLOT_JOB_ID,
+      processor_type: "plot",
+      status: "processing",
+      submitted_at: Date.now(),
+      result_uri: null,
+      error_message: null,
+      diagnostics: null,
+    });
+    const { GET } = await importDownloadRoute();
+    const res = await GET(makeDownloadRequest(PLOT_JOB_ID, "1.1.3.3"));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/not ready/i);
+  });
+
+  it("returns 400 and never fetches when result_uri is on a non-allowlisted host", async () => {
+    getJobStatusMock.mockResolvedValue({
+      job_id: PLOT_JOB_ID,
+      processor_type: "plot",
+      status: "succeeded",
+      submitted_at: Date.now(),
+      result_uri: "https://evil.example.com/plot.png",
+      error_message: null,
+      diagnostics: null,
+    });
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const { GET } = await importDownloadRoute();
+    const res = await GET(makeDownloadRequest(PLOT_JOB_ID, "1.1.3.4"));
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("streams the plot with attachment headers on the happy path", async () => {
+    getJobStatusMock.mockResolvedValue({
+      job_id: PLOT_JOB_ID,
+      processor_type: "plot",
+      status: "succeeded",
+      submitted_at: Date.now(),
+      result_uri: SIGNED_URL,
+      error_message: null,
+      diagnostics: null,
+    });
+    const fakeBody = new ReadableStream();
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(fakeBody, {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+    );
+    const { GET } = await importDownloadRoute();
+    const res = await GET(makeDownloadRequest(PLOT_JOB_ID, "1.1.3.5"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    expect(res.headers.get("content-disposition")).toMatch(/^attachment; filename="og-method-comparison-.*\.png"$/);
+
+    const [calledUrl, calledInit] = fetchSpy.mock.calls[0];
+    expect(calledUrl).toBe(SIGNED_URL);
+    expect((calledInit as RequestInit).redirect).toBe("error");
+    fetchSpy.mockRestore();
+  });
+
+  it("returns a 502 JSON error when the upstream fetch rejects", async () => {
+    getJobStatusMock.mockResolvedValue({
+      job_id: PLOT_JOB_ID,
+      processor_type: "plot",
+      status: "succeeded",
+      submitted_at: Date.now(),
+      result_uri: SIGNED_URL,
+      error_message: null,
+      diagnostics: null,
+    });
+    const fetchSpy = vi.spyOn(global, "fetch").mockRejectedValue(new TypeError("fetch failed"));
+    const { GET } = await importDownloadRoute();
+    const res = await GET(makeDownloadRequest(PLOT_JOB_ID, "1.1.3.6"));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toMatch(/upstream fetch failed/i);
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
The demo's rendered plots need to be downloadable (owner request — they go on the marketing site). Signed GCS URLs are cross-origin, where `<a download>` is ignored and the bucket serves no CORS headers for a client-side blob fetch — so downloads go through a new admin-gated proxy route that fetches the signed URL server-side and streams it back with `Content-Disposition: attachment` and a timestamped filename.

**SSRF guard:** only `https://storage.googleapis.com/<our-staging-bucket>/…` URLs are fetched; anything else is rejected 400 before any request leaves the server.

## Test plan
- tsc + lint clean
- Live: click Download PNG after a demo run → file saves as `og-method-comparison-<stamp>.png`; expired signed URL → clear 502 message

🤖 Generated with [Claude Code](https://claude.com/claude-code)