### PR TITLE
feat(og-demo): chain one multi-panel plot after ALL methods succeed

### DIFF
--- a/src/app/admin/omni-gridder/page.tsx
+++ b/src/app/admin/omni-gridder/page.tsx
@@ -105,6 +105,15 @@ export default function OmniGridderDemoPage() {
   // poll so the server can chain a before/after plot (server re-validates
   // it against its own allowlist; this is display plumbing, not authority).
   const inputUriRef = useRef<string>('')
+  // Comparison mode: all regrid job ids from the batch, the set that have
+  // succeeded so far, and whether the (single) multi-panel plot chain has
+  // fired. The panel plot must wait for EVERY method to finish — chaining
+  // on the primary alone would render panels for outputs that don't exist
+  // yet. Server-side, the ids are re-validated and mapped to output URIs
+  // by the server's own convention (see the status route).
+  const panelJobIdsRef = useRef<string[]>([])
+  const succeededJobsRef = useRef<Set<string>>(new Set())
+  const panelChainFiredRef = useRef(false)
 
   const log = useCallback((label: string) => {
     setTimeline((prev) => [...prev, { at: Date.now(), label }])
@@ -136,8 +145,12 @@ export default function OmniGridderDemoPage() {
   ): Promise<void> {
     let res: Response
     try {
+      const panelsQs =
+        panelJobIdsRef.current.length > 1
+          ? `&panels=${encodeURIComponent(panelJobIdsRef.current.join(','))}`
+          : ''
       const qs = chainPlot
-        ? `?chainPlot=1${inputUriRef.current ? `&compare=${encodeURIComponent(inputUriRef.current)}` : ''}`
+        ? `?chainPlot=1${inputUriRef.current ? `&compare=${encodeURIComponent(inputUriRef.current)}` : ''}${panelsQs}`
         : ''
       res = await fetch(`/api/admin/omni-gridder/status/${jobId}${qs}`)
     } catch {
@@ -211,6 +224,24 @@ export default function OmniGridderDemoPage() {
           data.nextJobId,
           setTimeout(() => pollJob(data.nextJobId!, method, false, true, null), POLL_INTERVAL_MS),
         )
+        return
+      }
+      // Comparison mode: the multi-panel plot needs EVERY method's output on
+      // GCS, so no per-method poll carries chainPlot — instead, the last
+      // method to succeed fires one chain request against the primary job,
+      // whose panels= param lists the whole batch.
+      succeededJobsRef.current.add(jobId)
+      if (
+        panelJobIdsRef.current.length > 1 &&
+        !panelChainFiredRef.current &&
+        panelJobIdsRef.current.every((id) => succeededJobsRef.current.has(id))
+      ) {
+        panelChainFiredRef.current = true
+        const primary =
+          panelJobIdsRef.current.find((id) => id.endsWith(`-${PRIMARY_METHOD}`)) ??
+          panelJobIdsRef.current[0]
+        log('All methods succeeded — chaining multi-panel comparison plot')
+        void pollJob(primary, PRIMARY_METHOD, true, false, 'succeeded')
       }
       return
     }
@@ -277,11 +308,23 @@ export default function OmniGridderDemoPage() {
       }
 
       const submittedAt = Date.now()
+      const comparisonMode = data.jobs.length > 1
+      // Comparison mode chains ONE multi-panel plot only after ALL methods
+      // succeed (see the succeeded branch in pollJob) — so no per-method
+      // poll carries chainPlot. Single-method mode keeps chaining its own
+      // before/after plot directly.
+      panelJobIdsRef.current = comparisonMode ? data.jobs.map((j) => j.jobId) : []
+      succeededJobsRef.current = new Set()
+      panelChainFiredRef.current = false
       const hasPrimary = data.jobs.some((j) => j.method === PRIMARY_METHOD)
       for (const { jobId, method } of data.jobs) {
         log(`Submitted ${jobId}`)
         updateRow(method, { jobId, status: 'queued', submittedAt })
-        const chainPlot = hasPrimary ? method === PRIMARY_METHOD : method === data.jobs[0].method
+        const chainPlot = comparisonMode
+          ? false
+          : hasPrimary
+            ? method === PRIMARY_METHOD
+            : method === data.jobs[0].method
         pollTimers.current.set(
           jobId,
           setTimeout(() => pollJob(jobId, method, chainPlot, false, null), POLL_INTERVAL_MS),

--- a/src/app/api/admin/omni-gridder/status/[jobId]/route.ts
+++ b/src/app/api/admin/omni-gridder/status/[jobId]/route.ts
@@ -45,6 +45,33 @@ export async function GET(
     // worker reads this URI from GCS, so it must never be client-arbitrary.
     const compare = request.nextUrl.searchParams.get('compare')
     const compareUri = compare && allowedInputUris().includes(compare) ? compare : undefined
+
+    // Comparison mode: ?panels=<jobId,jobId,...> chains ONE multi-panel plot
+    // (input + every method's output) once the client has seen all methods
+    // succeed. Only job IDs are accepted — each is strictly validated and
+    // its output URI reconstructed from OUR bucket/jobId convention, so the
+    // client never supplies a URI. Invalid ids are a loud 400, not a silent
+    // drop: a typo'd panel list should never quietly render fewer methods.
+    const panelsRaw = request.nextUrl.searchParams.get('panels')
+    let panelUris: { uri: string; label: string }[] | undefined
+    if (panelsRaw) {
+      const ids = panelsRaw.split(',').map((s) => s.trim()).filter(Boolean)
+      const idPattern = /^[a-z][a-z0-9-]{0,58}-(nearest|bilinear|conservative|ewa)$/
+      if (ids.length === 0 || ids.length > 4 || ids.some((id) => !idPattern.test(id))) {
+        return NextResponse.json(
+          { error: 'panels must be 1-4 valid regrid job ids' },
+          { status: 400 },
+        )
+      }
+      panelUris = ids.map((id) => {
+        const method = id.slice(id.lastIndexOf('-') + 1)
+        return {
+          uri: `gs://${GCS_STAGING_BUCKET}/demo/regrid/${id}/output.nc`,
+          label: method.charAt(0).toUpperCase() + method.slice(1),
+        }
+      })
+    }
+
     const plotJobId = `${jobId}${PLOT_SUFFIX}`
     await submitJob({
       job_id: plotJobId,
@@ -57,6 +84,7 @@ export async function GET(
         title: 'Agentic OG — Method Comparison Demo',
         colormap: 'RdYlBu_r',
         ...(compareUri ? { compare_uri: compareUri } : {}),
+        ...(panelUris ? { panel_uris: panelUris } : {}),
       },
     })
     return NextResponse.json({ ...status, nextJobId: plotJobId })

--- a/tests/integration/omni-gridder-api.test.ts
+++ b/tests/integration/omni-gridder-api.test.ts
@@ -256,6 +256,46 @@ describe("GET /api/admin/omni-gridder/status/[jobId] — chainPlot gating", () =
     const params = submitJobMock.mock.calls[0][0].params as Record<string, unknown>;
     expect(params.compare_uri).toBeUndefined();
   });
+
+  it("maps a valid ?panels= list to reconstructed panel_uris with method labels", async () => {
+    getJobStatusMock.mockResolvedValue(baseStatus);
+    const { GET } = await importStatusRoute();
+
+    const panels = ["demo-batch-nearest", "demo-batch-bilinear", "demo-batch-conservative"];
+    const req = new NextRequest(
+      `http://localhost/api/admin/omni-gridder/status/${baseStatus.job_id}?chainPlot=1&panels=${encodeURIComponent(panels.join(","))}`,
+      { headers: adminHeaders("1.1.2.6") },
+    );
+    const res = await GET(req, { params: Promise.resolve({ jobId: baseStatus.job_id }) });
+    expect(res.status).toBe(200);
+
+    const params = submitJobMock.mock.calls[0][0].params as {
+      panel_uris: { uri: string; label: string }[];
+    };
+    expect(params.panel_uris).toHaveLength(3);
+    expect(params.panel_uris[0]).toEqual({
+      uri: "gs://test-staging-bucket/demo/regrid/demo-batch-nearest/output.nc",
+      label: "Nearest",
+    });
+    expect(params.panel_uris.map((p) => p.label)).toEqual([
+      "Nearest",
+      "Bilinear",
+      "Conservative",
+    ]);
+  });
+
+  it("rejects an invalid ?panels= job id with 400 and submits nothing", async () => {
+    getJobStatusMock.mockResolvedValue(baseStatus);
+    const { GET } = await importStatusRoute();
+
+    const req = new NextRequest(
+      `http://localhost/api/admin/omni-gridder/status/${baseStatus.job_id}?chainPlot=1&panels=${encodeURIComponent("demo-batch-nearest,gs://evil/../../x")}`,
+      { headers: adminHeaders("1.1.2.7") },
+    );
+    const res = await GET(req, { params: Promise.resolve({ jobId: baseStatus.job_id }) });
+    expect(res.status).toBe(400);
+    expect(submitJobMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("GET /api/admin/omni-gridder/download", () => {


### PR DESCRIPTION
## Summary
Completes the comparison demo's visual: instead of a single bilinear before/after, the last method to succeed fires **one** chain request listing the whole batch (`panels=`), and the server submits a single plot job rendering **Input + Nearest + Bilinear + Conservative** in a 2×2 grid with a shared color scale (worker-side renderer from omni-gridder#62).

**Security posture unchanged:** only job IDs cross the wire — strict pattern validation (400 on any invalid id, no silent drops), output URIs reconstructed server-side from our own bucket/jobId convention. Single-method mode keeps its direct before/after chain.

## Test plan
- 13/13 integration tests green (new: valid panels → reconstructed `panel_uris` with method labels; invalid id → 400, nothing submitted); tsc clean
- Live after worker redeploy (in progress): comparison run → one 2×2 panel image, downloadable via the Download PNG button

🤖 Generated with [Claude Code](https://claude.com/claude-code)