### PR TITLE
fix(proxy): authenticated admin API traffic gets its own rate ceiling

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -125,13 +125,20 @@ export async function proxy(request: NextRequest) {
              request.headers.get('x-real-ip') ||
              'unknown'
   const isApiRoute = pathname === '/api' || pathname.startsWith('/api/')
-  const maxRequests = 100
+  // Authenticated admin API traffic gets a far higher ceiling: the coarse
+  // limit exists for anonymous abuse, but the passphrase-gated demo page
+  // legitimately polls job status every few seconds (a 3-method comparison
+  // run alone is ~100 requests), and the old shared 100/15min budget made
+  // the Download button 429 right after a successful run.
+  const isAuthedAdminApi =
+    isApiRoute && pathname.startsWith('/api/admin/') && (await isAdminSession(request))
+  const maxRequests = isAuthedAdminApi ? 2000 : 100
   let rateRemaining = maxRequests - 1
   if (isApiRoute) {
     const result = await rateLimit(ip, {
       limit: maxRequests,
       windowMs: 15 * 60 * 1000, // 15 minutes
-      prefix: 'proxy-api',
+      prefix: isAuthedAdminApi ? 'proxy-api-admin' : 'proxy-api',
     })
     rateRemaining = result.remaining
     if (!result.success) {


### PR DESCRIPTION
## Summary
Owner-reported: clicking **Download PNG** right after a comparison run returned 'Rate limit exceeded'. Root cause: the site-wide coarse limit (100 req/15min/IP on all `/api/*`) is sized for anonymous abuse, but the admin demo legitimately polls job status every few seconds — a single 3-method comparison run consumes roughly the whole budget, so the download request tipped it over.

Fix: requests to `/api/admin/*` carrying a **valid admin session** (checked via the proxy's existing `isAdminSession`) use a separate 2000/15min bucket. Anonymous traffic keeps the original 100/15min. No route-level limits changed (submit keeps its own tighter 2-comparisons/2min budget).

## Test plan
- tsc clean, full vitest suite green
- Live: run a comparison, then Download PNG immediately — no 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)