### PR TITLE
feat(brand): reconcile site ink to brand Ink Black #101820; formalize token ramp

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,13 +5,19 @@ html {
 }
 
 :root {
-  --background: #0d0c0f;
+  /* Aetheris Vision brand tokens — canonical source: Figma "Aetheris Vision
+     Brand System" (Brand Brief page), reconciled with the shipped site
+     2026-07-09. Typography ratified: Newsreader (display serif) + Inter
+     (body). Do not introduce ad-hoc colors — extend this ramp. */
+  --background: #101820; /* brand "Ink Black" (was #0d0c0f pre-reconciliation) */
   --foreground: #eae8ec;
-  --av-navy: #29426c;
-  --av-mid: #486890;
-  --av-accent: #5ba8d9;
-  --av-light: #7eabca;
-  --av-cyan: #6ec4d6;
+  --av-midnight: #0a1628; /* brand "Midnight Navy" — deepest surface/header band */
+  --av-navy: #29426c; /* brand "Aetheris Navy" */
+  --av-mid: #486890; /* brand "Mid Blue" */
+  --av-accent: #5ba8d9; /* brand "Sky Accent" */
+  --av-light: #7eabca; /* brand "Pale Sky" */
+  --av-cyan: #6ec4d6; /* brand "Data Cyan" — data/diagnostics highlight (promoted from site use 2026-07-09) */
+  --av-ice: #f3f7f9; /* brand "Ice Gray" — light panels on print/light surfaces */
 }
 
 @theme inline {
@@ -19,11 +25,13 @@ html {
   --font-serif: var(--font-newsreader), ui-serif, Georgia, serif;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-av-midnight: var(--av-midnight);
   --color-av-navy: var(--av-navy);
   --color-av-mid: var(--av-mid);
   --color-av-accent: var(--av-accent);
   --color-av-light: var(--av-light);
   --color-av-cyan: var(--av-cyan);
+  --color-av-ice: var(--av-ice);
 }
 
 body {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -145,7 +145,7 @@ export default async function Home() {
         </section>
 
         {/* Real Proof Section */}
-        <section className="py-24 bg-[#101820] border-t border-white/5">
+        <section className="py-24 bg-background border-t border-white/5">
           <div className="mx-auto max-w-5xl px-6">
             <FadeIn>
               <h2 className="text-sm font-semibold tracking-widest text-blue-500 uppercase mb-3">Real Output</h2>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,7 +68,7 @@ export default async function Home() {
             />
           </div>
 
-          <div className="absolute inset-0 bg-gradient-to-b from-[#0d0c0f]/40 via-[#0d0c0f]/90 to-[#0d0c0f] -z-10" />
+          <div className="absolute inset-0 bg-gradient-to-b from-[#101820]/40 via-[#101820]/90 to-[#101820] -z-10" />
 
           <SatelliteDisplay sources={sources} />
 
@@ -120,7 +120,7 @@ export default async function Home() {
               sizes="100vw"
             />
           </div>
-          <div className="absolute inset-0 bg-gradient-to-r from-[#0d0c0f] via-[#0d0c0f]/85 to-[#0d0c0f]/25 -z-10" />
+          <div className="absolute inset-0 bg-gradient-to-r from-[#101820] via-[#101820]/85 to-[#101820]/25 -z-10" />
 
           <div className="mx-auto max-w-5xl px-6">
             <FadeIn delay={0}>
@@ -145,7 +145,7 @@ export default async function Home() {
         </section>
 
         {/* Real Proof Section */}
-        <section className="py-24 bg-[#0d0c0f] border-t border-white/5">
+        <section className="py-24 bg-[#101820] border-t border-white/5">
           <div className="mx-auto max-w-5xl px-6">
             <FadeIn>
               <h2 className="text-sm font-semibold tracking-widest text-blue-500 uppercase mb-3">Real Output</h2>
@@ -190,7 +190,7 @@ export default async function Home() {
             className="object-cover"
             sizes="100vw"
           />
-          <div className="absolute inset-0 bg-gradient-to-t from-[#0d0c0f] via-[#0d0c0f]/60 to-[#0d0c0f]/20" />
+          <div className="absolute inset-0 bg-gradient-to-t from-[#101820] via-[#101820]/60 to-[#101820]/20" />
           <div className="absolute inset-0 flex items-end">
             <div className="mx-auto max-w-5xl px-6 pb-8 w-full">
               <FadeIn>
@@ -224,7 +224,7 @@ export default async function Home() {
                       className="object-cover object-[50%_22%] opacity-[0.65] group-hover:opacity-[0.8] transition-opacity duration-500"
                       sizes="(max-width: 768px) 100vw, 33vw"
                     />
-                    <div className="absolute inset-0 bg-gradient-to-b from-[#0d0c0f]/20 via-[#0d0c0f]/70 to-[#0d0c0f]/92" />
+                    <div className="absolute inset-0 bg-gradient-to-b from-[#101820]/20 via-[#101820]/70 to-[#101820]/92" />
                   </div>
                   <div className="relative z-10">
                     <div className="h-12 w-12 rounded-lg bg-gray-900 border border-blue-500/30 flex items-center justify-center mb-6">
@@ -249,7 +249,7 @@ export default async function Home() {
                       className="object-cover opacity-[0.65] group-hover:opacity-[0.8] transition-opacity duration-500"
                       sizes="(max-width: 768px) 100vw, 33vw"
                     />
-                    <div className="absolute inset-0 bg-gradient-to-b from-[#0d0c0f]/20 via-[#0d0c0f]/70 to-[#0d0c0f]/92" />
+                    <div className="absolute inset-0 bg-gradient-to-b from-[#101820]/20 via-[#101820]/70 to-[#101820]/92" />
                   </div>
                   <div className="relative z-10">
                     <div className="h-12 w-12 rounded-lg bg-gray-900 border border-white/10 flex items-center justify-center mb-6">
@@ -277,7 +277,7 @@ export default async function Home() {
                       className="object-cover object-[50%_72%] opacity-[0.8] group-hover:opacity-[0.95] transition-opacity duration-500"
                       sizes="(max-width: 768px) 100vw, 33vw"
                     />
-                    <div className="absolute inset-0 bg-gradient-to-b from-[#0d0c0f]/10 via-[#0d0c0f]/50 to-[#0d0c0f]/85" />
+                    <div className="absolute inset-0 bg-gradient-to-b from-[#101820]/10 via-[#101820]/50 to-[#101820]/85" />
                   </div>
                   <div className="relative z-10">
                     <div className="h-12 w-12 rounded-lg bg-gray-900 border border-white/10 flex items-center justify-center mb-6">
@@ -312,7 +312,7 @@ export default async function Home() {
                     className="object-cover object-[50%_45%] opacity-[0.5]"
                     sizes="(max-width: 1024px) 100vw, 1024px"
                   />
-                  <div className="absolute inset-0 bg-gradient-to-r from-[#0d0c0f]/95 via-[#0d0c0f]/75 to-[#0d0c0f]/35" />
+                  <div className="absolute inset-0 bg-gradient-to-r from-[#101820]/95 via-[#101820]/75 to-[#101820]/35" />
                 </div>
                 {/* Glow */}
                 <div className="absolute -bottom-20 -right-20 w-72 h-72 rounded-full bg-blue-600/10 blur-3xl pointer-events-none" />

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function ReviewPage() {
   return (
-    <div className="flex flex-col min-h-[100dvh] bg-[#101820]">
+    <div className="flex flex-col min-h-[100dvh] bg-background">
       <Navbar />
 
       <main id="main" className="flex-1 py-24 px-6">

--- a/src/app/review/page.tsx
+++ b/src/app/review/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function ReviewPage() {
   return (
-    <div className="flex flex-col min-h-[100dvh] bg-[#0d0c0f]">
+    <div className="flex flex-col min-h-[100dvh] bg-[#101820]">
       <Navbar />
 
       <main id="main" className="flex-1 py-24 px-6">

--- a/src/app/services/web/page.tsx
+++ b/src/app/services/web/page.tsx
@@ -128,7 +128,7 @@ export default function WebServicesPage() {
         </section>
 
         {/* Services Grid */}
-        <section className="border-t border-white/5 bg-[#101820] py-20">
+        <section className="border-t border-white/5 bg-background py-20">
           <div className="mx-auto max-w-5xl px-6">
             <FadeIn>
               <h2 className="text-2xl md:text-3xl font-semibold text-white mb-12">What We Build</h2>
@@ -172,7 +172,7 @@ export default function WebServicesPage() {
         </section>
 
         {/* Process */}
-        <section className="border-t border-white/5 bg-[#101820] py-20">
+        <section className="border-t border-white/5 bg-background py-20">
           <div className="mx-auto max-w-5xl px-6">
             <FadeIn>
               <h2 className="text-2xl md:text-3xl font-semibold text-white mb-3">How It Works</h2>
@@ -219,7 +219,7 @@ export default function WebServicesPage() {
         </section>
 
         {/* CTA */}
-        <section className="border-t border-white/5 bg-[#101820] py-20">
+        <section className="border-t border-white/5 bg-background py-20">
           <div className="mx-auto max-w-5xl px-6 text-center">
             <FadeIn>
               <h2 className="text-3xl md:text-4xl font-semibold text-white mb-4">Ready to get started?</h2>

--- a/src/app/services/web/page.tsx
+++ b/src/app/services/web/page.tsx
@@ -128,7 +128,7 @@ export default function WebServicesPage() {
         </section>
 
         {/* Services Grid */}
-        <section className="border-t border-white/5 bg-[#0d0c0f] py-20">
+        <section className="border-t border-white/5 bg-[#101820] py-20">
           <div className="mx-auto max-w-5xl px-6">
             <FadeIn>
               <h2 className="text-2xl md:text-3xl font-semibold text-white mb-12">What We Build</h2>
@@ -172,7 +172,7 @@ export default function WebServicesPage() {
         </section>
 
         {/* Process */}
-        <section className="border-t border-white/5 bg-[#0d0c0f] py-20">
+        <section className="border-t border-white/5 bg-[#101820] py-20">
           <div className="mx-auto max-w-5xl px-6">
             <FadeIn>
               <h2 className="text-2xl md:text-3xl font-semibold text-white mb-3">How It Works</h2>
@@ -219,7 +219,7 @@ export default function WebServicesPage() {
         </section>
 
         {/* CTA */}
-        <section className="border-t border-white/5 bg-[#0d0c0f] py-20">
+        <section className="border-t border-white/5 bg-[#101820] py-20">
           <div className="mx-auto max-w-5xl px-6 text-center">
             <FadeIn>
               <h2 className="text-3xl md:text-4xl font-semibold text-white mb-4">Ready to get started?</h2>

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -149,7 +149,7 @@ export default function ChatWidget() {
         <div
           role="region"
           aria-label="Chat"
-          className="fixed bottom-24 left-6 z-50 flex w-[22rem] flex-col rounded-2xl border border-white/10 bg-[#101820] shadow-2xl overflow-hidden"
+          className="fixed bottom-24 left-6 z-50 flex w-[22rem] flex-col rounded-2xl border border-white/10 bg-background shadow-2xl overflow-hidden"
           style={{ maxHeight: "min(32rem, calc(100svh - 8rem))" }}
         >
 

--- a/src/components/ChatWidget.tsx
+++ b/src/components/ChatWidget.tsx
@@ -149,7 +149,7 @@ export default function ChatWidget() {
         <div
           role="region"
           aria-label="Chat"
-          className="fixed bottom-24 left-6 z-50 flex w-[22rem] flex-col rounded-2xl border border-white/10 bg-[#0d0c0f] shadow-2xl overflow-hidden"
+          className="fixed bottom-24 left-6 z-50 flex w-[22rem] flex-col rounded-2xl border border-white/10 bg-[#101820] shadow-2xl overflow-hidden"
           style={{ maxHeight: "min(32rem, calc(100svh - 8rem))" }}
         >
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,7 +16,7 @@ const footerLinks = [
 
 export default function Footer() {
   return (
-    <footer className="border-t border-white/5 bg-[#101820]">
+    <footer className="border-t border-white/5 bg-background">
       <div className="mx-auto max-w-5xl px-6 py-12">
         {/* Top row: logo + nav */}
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-8 mb-10">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,7 +16,7 @@ const footerLinks = [
 
 export default function Footer() {
   return (
-    <footer className="border-t border-white/5 bg-[#0d0c0f]">
+    <footer className="border-t border-white/5 bg-[#101820]">
       <div className="mx-auto max-w-5xl px-6 py-12">
         {/* Top row: logo + nav */}
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-8 mb-10">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,7 +11,6 @@ import { BRAND_LOGO } from "@/lib/brand";
 const navLinks = [
   { label: "Agentic OG", href: "/agentic-og" },
   { label: "About", href: "/about" },
-  { label: "Services", href: "/services" },
   { label: "Capabilities", href: "/capabilities" },
   { label: "Portfolio", href: "/portfolio" },
   { label: "Blog", href: "/blog" },
@@ -43,7 +42,7 @@ export default function Navbar() {
     if (href === "/metrics") return pathname === "/metrics";
     if (href === "/portfolio") return pathname.startsWith("/portfolio");
     if (href === "/contact") return pathname === "/contact";
-    if (href === "/services") return pathname.startsWith("/services");
+    if (href === "/services/web") return pathname.startsWith("/services");
     return false;
   }
 
@@ -52,8 +51,8 @@ export default function Navbar() {
       className={clsx(
         "fixed top-0 w-full z-50 border-b transition-all duration-300",
         scrolled
-          ? "border-white/10 bg-[#0d0c0f]/88 backdrop-blur-md shadow-[0_1px_30px_rgba(0,0,0,0.5)]"
-          : "border-white/5 bg-[#0d0c0f]/50 backdrop-blur-sm"
+          ? "border-white/10 bg-[#101820]/88 backdrop-blur-md shadow-[0_1px_30px_rgba(0,0,0,0.5)]"
+          : "border-white/5 bg-[#101820]/50 backdrop-blur-sm"
       )}
     >
       <div
@@ -124,7 +123,7 @@ export default function Navbar() {
 
       {/* Mobile Menu Panel */}
       {mobileOpen && (
-        <div className="md:hidden border-t border-white/5 bg-[#0d0c0f]/97 backdrop-blur-md">
+        <div className="md:hidden border-t border-white/5 bg-[#101820]/97 backdrop-blur-md">
           <nav className="mx-auto max-w-5xl px-6 py-4 flex flex-col gap-1">
             {navLinks.map((link) => (
               <a

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,6 +11,7 @@ import { BRAND_LOGO } from "@/lib/brand";
 const navLinks = [
   { label: "Agentic OG", href: "/agentic-og" },
   { label: "About", href: "/about" },
+  { label: "Services", href: "/services" },
   { label: "Capabilities", href: "/capabilities" },
   { label: "Portfolio", href: "/portfolio" },
   { label: "Blog", href: "/blog" },
@@ -42,7 +43,7 @@ export default function Navbar() {
     if (href === "/metrics") return pathname === "/metrics";
     if (href === "/portfolio") return pathname.startsWith("/portfolio");
     if (href === "/contact") return pathname === "/contact";
-    if (href === "/services/web") return pathname.startsWith("/services");
+    if (href === "/services") return pathname.startsWith("/services");
     return false;
   }
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -51,8 +51,8 @@ export default function Navbar() {
       className={clsx(
         "fixed top-0 w-full z-50 border-b transition-all duration-300",
         scrolled
-          ? "border-white/10 bg-[#101820]/88 backdrop-blur-md shadow-[0_1px_30px_rgba(0,0,0,0.5)]"
-          : "border-white/5 bg-[#101820]/50 backdrop-blur-sm"
+          ? "border-white/10 bg-background/88 backdrop-blur-md shadow-[0_1px_30px_rgba(0,0,0,0.5)]"
+          : "border-white/5 bg-background/50 backdrop-blur-sm"
       )}
     >
       <div
@@ -123,7 +123,7 @@ export default function Navbar() {
 
       {/* Mobile Menu Panel */}
       {mobileOpen && (
-        <div className="md:hidden border-t border-white/5 bg-[#101820]/97 backdrop-blur-md">
+        <div className="md:hidden border-t border-white/5 bg-background/97 backdrop-blur-md">
           <nav className="mx-auto max-w-5xl px-6 py-4 flex flex-col gap-1">
             {navLinks.map((link) => (
               <a

--- a/src/lib/brand.ts
+++ b/src/lib/brand.ts
@@ -9,7 +9,7 @@ export const BRAND = {
   light: "#7EABCA",
   accent: "#5BA8D9",
   cyan: "#6EC4D6",
-  siteBackground: "#0d0c0f",
+  siteBackground: "#101820",
   siteForeground: "#eae8ec",
 } as const;
 


### PR DESCRIPTION
## Summary
Implements the owner-ratified brand reconciliation (2026-07-09): the site background moves from the ad-hoc `#0d0c0f` to the Brand System's **Ink Black `#101820`** — swept across globals.css and every hardcoded occurrence (page, review, services/web, Navbar, ChatWidget, Footer, brand.ts; canonical `tokens.json` synced in the aetherisvision repo). The token ramp is formalized with brand names: Midnight Navy `#0A1628` (new), Data Cyan `#6EC4D6` (promoted), Ice Gray `#F3F7F9` (new); typography pairing (Newsreader display serif + Inter body) documented as ratified.

Pre-authorized to merge (internal visual alignment). Visual check: Vercel preview — background should read very slightly warmer/bluer, everything else identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)