### PR TITLE
refactor(#89): extract shared omni-gridder proxy lib (increment 1)

### DIFF
--- a/src/app/api/admin/omni-gridder/download/route.ts
+++ b/src/app/api/admin/omni-gridder/download/route.ts
@@ -1,102 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
-import { getJobStatus } from '@/lib/omni-gridder-client'
-
-const GCS_STAGING_BUCKET = process.env.OG_GCS_STAGING_BUCKET
-
-// Job IDs are our own generated strings (see submit/route.ts and
-// status/[jobId]/route.ts), always lowercase-alnum-hyphen and always ending
-// in "-plot" for the chained plot job this route serves. Reject anything
-// else before it ever reaches getJobStatus.
-const PLOT_JOB_ID_RE = /^[a-z][a-z0-9-]{0,62}-plot$/
+import { downloadPlot, proxyErrorResponse } from '@/lib/omni-gridder-proxy'
 
 // Streams a rendered plot back with attachment headers so the browser
-// downloads it instead of navigating. A plain <a download> can't do this:
-// the signed URL is cross-origin (storage.googleapis.com), where the
-// download attribute is ignored, and the bucket serves no CORS headers for
-// a client-side blob fetch. Fetching server-side sidesteps both.
-//
-// Looked up by job id, not by URL: the client never sees or holds the
-// signed bearer URL in a query string. We resolve job -> status -> result_uri
-// ourselves via getJobStatus() (the same og-server client the status route
-// uses), and only THEN apply the host/path allowlist below — as defense in
-// depth, not as the primary authority (og-server is the only thing that
-// ever produces a value here, and it only ever returns signed URLs).
+// downloads it instead of navigating. Job resolution, signed-URL allowlisting,
+// and upstream fetching all live in downloadPlot() (shared proxy module); this
+// route only enforces admin auth and wraps the result stream.
 export async function GET(request: NextRequest) {
   if (!isAdmin(request)) return unauthorizedResponse()
-  if (!GCS_STAGING_BUCKET) {
-    return NextResponse.json({ error: 'OG_GCS_STAGING_BUCKET is not set' }, { status: 500 })
-  }
 
-  const jobId = request.nextUrl.searchParams.get('job')
-  if (!jobId || !PLOT_JOB_ID_RE.test(jobId)) {
-    return NextResponse.json(
-      { error: 'job query param required — must be a plot job id ending in "-plot"' },
-      { status: 400 },
-    )
-  }
+  const outcome = await downloadPlot(request.nextUrl.searchParams.get('job'))
+  if (!outcome.ok) return proxyErrorResponse(outcome)
 
-  let status
-  try {
-    status = await getJobStatus(jobId)
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    return NextResponse.json({ error: `Job lookup failed: ${message}` }, { status: 502 })
-  }
-  if (!status) {
-    return NextResponse.json({ error: 'Job not found' }, { status: 404 })
-  }
-  if (status.status !== 'succeeded' || !status.result_uri) {
-    return NextResponse.json(
-      { error: `Job is not ready for download (status: ${status.status})` },
-      { status: 409 },
-    )
-  }
-
-  let target: URL
-  try {
-    target = new URL(status.result_uri)
-  } catch {
-    return NextResponse.json({ error: 'og-server returned an invalid result URL' }, { status: 502 })
-  }
-  const validHost = target.hostname === 'storage.googleapis.com'
-  const validPath = target.pathname.startsWith(`/${GCS_STAGING_BUCKET}/`)
-  if (target.protocol !== 'https:' || !validHost || !validPath) {
-    return NextResponse.json(
-      { error: 'result URL must be a signed storage.googleapis.com link for the demo bucket' },
-      { status: 400 },
-    )
-  }
-
-  let upstream: Response
-  try {
-    upstream = await fetch(target.toString(), {
-      // A redirect off the allowlisted host must fail outright, never be
-      // followed — 'follow' would let a compromised/misconfigured upstream
-      // hop us to an arbitrary origin after the guard above already passed.
-      redirect: 'error',
-      signal: AbortSignal.timeout(20_000),
-    })
-  } catch (err) {
-    // fetch() throws (doesn't resolve to a non-ok Response) on DNS failure,
-    // network errors, timeout, and a blocked redirect — all of those must
-    // come back as JSON, not surface as Next's HTML 500 page.
-    const message = err instanceof Error ? err.message : String(err)
-    return NextResponse.json({ error: `Upstream fetch failed: ${message}` }, { status: 502 })
-  }
-
-  if (!upstream.ok || !upstream.body) {
-    return NextResponse.json(
-      { error: `upstream fetch failed (${upstream.status}) — the signed URL may have expired; re-run the job` },
-      { status: 502 },
-    )
-  }
-
-  const stamp = new Date().toISOString().slice(0, 16).replace(/[:T]/g, '-')
-  return new NextResponse(upstream.body, {
+  return new NextResponse(outcome.data.body, {
     headers: {
-      'Content-Type': upstream.headers.get('content-type') ?? 'image/png',
-      'Content-Disposition': `attachment; filename="og-method-comparison-${stamp}.png"`,
+      'Content-Type': outcome.data.contentType,
+      'Content-Disposition': `attachment; filename="${outcome.data.filename}"`,
       'Cache-Control': 'no-store',
     },
   })

--- a/src/app/api/admin/omni-gridder/status/[jobId]/route.ts
+++ b/src/app/api/admin/omni-gridder/status/[jobId]/route.ts
@@ -1,94 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
-import { getJobStatus, submitJob } from '@/lib/omni-gridder-client'
-import { allowedInputUris } from '@/lib/og-demo-inputs'
-
-const GCS_STAGING_BUCKET = process.env.OG_GCS_STAGING_BUCKET
-const PLOT_SUFFIX = '-plot'
+import { getRegridJobStatus, proxyErrorResponse } from '@/lib/omni-gridder-proxy'
 
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ jobId: string }> },
 ) {
   if (!isAdmin(request)) return unauthorizedResponse()
-  if (!GCS_STAGING_BUCKET) {
-    return NextResponse.json({ error: 'OG_GCS_STAGING_BUCKET is not set' }, { status: 500 })
-  }
 
   const { jobId } = await params
-  const status = await getJobStatus(jobId)
-  if (!status) {
-    return NextResponse.json({ error: 'Job not found' }, { status: 404 })
-  }
+  // The frontend opts a single "primary" poll loop into plot-chaining via
+  // ?chainPlot=1 (the bilinear job in comparison mode, or the sole job in
+  // single-method mode) so only one plot renders per batch. ?compare= and
+  // ?panels= tune the chained plot; both are re-validated server-side.
+  const outcome = await getRegridJobStatus(jobId, {
+    chainPlot: request.nextUrl.searchParams.get('chainPlot') === '1',
+    compare: request.nextUrl.searchParams.get('compare'),
+    panels: request.nextUrl.searchParams.get('panels'),
+  })
 
-  // In comparison mode three regrid jobs (nearest/bilinear/conservative)
-  // poll this route independently. Only ONE of them should chain a Plot
-  // job — otherwise every poller that lands after the transition submits
-  // its own plot, wasting worker cycles for images nobody's UI shows. The
-  // frontend opts a single "primary" poll loop in via ?chainPlot=1 (the
-  // bilinear job in comparison mode, or the sole job in single-method mode).
-  const chainPlot = request.nextUrl.searchParams.get('chainPlot') === '1'
-
-  // Once the regrid stage succeeds, chain a Plot job reading its output.
-  // Job IDs are unique-insert-only in og-server's job store (409 on
-  // duplicate), so re-submitting on every subsequent poll hit that lands
-  // after this transition is harmless — submitJob() already treats 409 as
-  // success. The Plot job's own gs:// input is reconstructed from the same
-  // bucket/jobId convention used at submit time, not parsed back out of the
-  // (signed, HTTPS) result_uri og-server returns — workers need a raw gs://
-  // URI to read via DataReader, not a browser-facing signed download link.
-  const isRegridJob = status.processor_type === 'regrid' && !jobId.endsWith(PLOT_SUFFIX)
-  if (chainPlot && isRegridJob && status.status === 'succeeded') {
-    // Optional before/after panel: the client passes back the input URI it
-    // was told at submit time (?compare=...); it is only honored if it's in
-    // the same server-side allowlist the submit route enforces — the plot
-    // worker reads this URI from GCS, so it must never be client-arbitrary.
-    const compare = request.nextUrl.searchParams.get('compare')
-    const compareUri = compare && allowedInputUris().includes(compare) ? compare : undefined
-
-    // Comparison mode: ?panels=<jobId,jobId,...> chains ONE multi-panel plot
-    // (input + every method's output) once the client has seen all methods
-    // succeed. Only job IDs are accepted — each is strictly validated and
-    // its output URI reconstructed from OUR bucket/jobId convention, so the
-    // client never supplies a URI. Invalid ids are a loud 400, not a silent
-    // drop: a typo'd panel list should never quietly render fewer methods.
-    const panelsRaw = request.nextUrl.searchParams.get('panels')
-    let panelUris: { uri: string; label: string }[] | undefined
-    if (panelsRaw) {
-      const ids = panelsRaw.split(',').map((s) => s.trim()).filter(Boolean)
-      const idPattern = /^[a-z][a-z0-9-]{0,58}-(nearest|bilinear|conservative|ewa)$/
-      if (ids.length === 0 || ids.length > 4 || ids.some((id) => !idPattern.test(id))) {
-        return NextResponse.json(
-          { error: 'panels must be 1-4 valid regrid job ids' },
-          { status: 400 },
-        )
-      }
-      panelUris = ids.map((id) => {
-        const method = id.slice(id.lastIndexOf('-') + 1)
-        return {
-          uri: `gs://${GCS_STAGING_BUCKET}/demo/regrid/${id}/output.nc`,
-          label: method.charAt(0).toUpperCase() + method.slice(1),
-        }
-      })
-    }
-
-    const plotJobId = `${jobId}${PLOT_SUFFIX}`
-    await submitJob({
-      job_id: plotJobId,
-      processor_type: 'plot',
-      kind: 'plot',
-      input_uri: `gs://${GCS_STAGING_BUCKET}/demo/regrid/${jobId}/output.nc`,
-      output_uri: `gs://${GCS_STAGING_BUCKET}/demo/regrid/${jobId}/plot.png`,
-      params: {
-        variable: 'HGT',
-        title: 'Agentic OG — Method Comparison Demo',
-        colormap: 'RdYlBu_r',
-        ...(compareUri ? { compare_uri: compareUri } : {}),
-        ...(panelUris ? { panel_uris: panelUris } : {}),
-      },
-    })
-    return NextResponse.json({ ...status, nextJobId: plotJobId })
-  }
-
-  return NextResponse.json(status)
+  if (!outcome.ok) return proxyErrorResponse(outcome)
+  return NextResponse.json(outcome.data)
 }

--- a/src/app/api/admin/omni-gridder/submit/route.ts
+++ b/src/app/api/admin/omni-gridder/submit/route.ts
@@ -1,129 +1,47 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
-import { allowedInputUris } from '@/lib/og-demo-inputs'
-import { submitJob, triggerWorkerRun } from '@/lib/omni-gridder-client'
 import { rateLimit } from '@/lib/rate-limit'
+import {
+  proxyErrorResponse,
+  submitRegridBatch,
+  type SubmitRequestBody,
+} from '@/lib/omni-gridder-proxy'
 
-const GCS_STAGING_BUCKET = process.env.OG_GCS_STAGING_BUCKET
-
-// 0.5° CONUS grid, generated server-side (never client-supplied — same SSRF/
-// resource-exhaustion reasoning as the input allowlist above: an arbitrary
-// dst_grid from the client could ask og-server to materialize an enormous
-// output array). lat 24..49 step 0.5 = 51 points; lon -125..-66 step 0.5 =
-// 119 points.
-function buildConusGrid(): { lat: number[]; lon: number[] } {
-  const lat: number[] = []
-  for (let i = 0; i <= 50; i++) lat.push(Math.round((24 + i * 0.5) * 1000) / 1000)
-  const lon: number[] = []
-  for (let i = 0; i <= 118; i++) lon.push(Math.round((-125 + i * 0.5) * 1000) / 1000)
-  return { lat, lon }
-}
-
-export type RegridMethod = 'nearest' | 'bilinear' | 'conservative'
-const VALID_METHODS: RegridMethod[] = ['nearest', 'bilinear', 'conservative']
-
-interface SubmitRequestBody {
-  /** One or more methods to run against the same input+grid. Defaults to ['bilinear']. */
-  methods?: string[]
-  /** Must be one of the server allowlist; defaults to the first allowlisted URI. */
-  inputUri?: string
-}
-
-interface SubmittedJob {
-  jobId: string
-  method: RegridMethod
-}
+// Re-exported for backward compatibility — the canonical definition now lives
+// in the shared proxy module.
+export type { RegridMethod } from '@/lib/omni-gridder-proxy'
 
 export async function POST(request: NextRequest) {
   if (!isAdmin(request)) return unauthorizedResponse()
-  if (!GCS_STAGING_BUCKET) {
-    return NextResponse.json({ error: 'OG_GCS_STAGING_BUCKET is not set' }, { status: 500 })
-  }
 
   const body = (await request.json().catch(() => ({}))) as SubmitRequestBody
 
-  const requestedMethods =
-    body.methods && body.methods.length > 0 ? body.methods : ['bilinear']
-  // Dedupe before validation/submission — {methods:["bilinear","bilinear"]}
-  // would otherwise submit the same jobId twice and schedule duplicate
-  // polling for what is really a single job. Preserve request order.
-  const methods = [...new Set(requestedMethods)] as string[]
-  const invalidMethod = methods.find((m) => !VALID_METHODS.includes(m as RegridMethod))
-  if (invalidMethod) {
-    return NextResponse.json(
-      { error: `Invalid method "${invalidMethod}" — must be one of ${VALID_METHODS.join(', ')}` },
-      { status: 400 },
-    )
-  }
-  if (methods.length > VALID_METHODS.length) {
-    return NextResponse.json({ error: 'Too many methods requested' }, { status: 400 })
-  }
-
-  const allowlist = allowedInputUris()
-  const inputUri = body.inputUri ?? allowlist[0]
-  if (!allowlist.includes(inputUri)) {
-    return NextResponse.json({ error: 'input URI is not in the server allowlist' }, { status: 400 })
-  }
-
-  // A submit triggers real Cloud Run job pickup — cheap, but not free, and
-  // not something an admin page should let run away with even though it's
-  // passphrase-gated. A comparison batch is up to 3 jobs in one call, so the
-  // per-request budget is tighter than the old single-job limit: one
-  // comparison (or a few singles) per 2-minute window per IP.
-  const ip = request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
-             request.headers.get('x-real-ip') ||
-             'unknown'
-  const limit = await rateLimit(ip, { limit: 2, windowMs: 2 * 60 * 1000, prefix: 'og-demo-submit' })
-  if (!limit.success) {
-    return NextResponse.json(
-      { error: 'Rate limit exceeded — wait before submitting another demo job' },
-      { status: 429, headers: { 'Retry-After': limit.retryAfterSeconds.toString() } },
-    )
-  }
-
-  const dstGrid = buildConusGrid()
-  const batchSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
-
-  // Everything past this point talks to external systems (WIF token
-  // minting, og-server, Cloud Run Admin API) — any throw here must come
-  // back as JSON with the real message, not Next's HTML 500 page, or the
-  // admin UI can only display a bare "HTTP 500" (which is exactly how a
-  // missing/stale env var hid from us in production).
-  try {
-    const submitted: SubmittedJob[] = []
-    for (const method of methods as RegridMethod[]) {
-      const jobId = `demo-${batchSuffix}-${method}`
-      const outputUri = `gs://${GCS_STAGING_BUCKET}/demo/regrid/${jobId}/output.nc`
-      await submitJob({
-        job_id: jobId,
-        processor_type: 'regrid',
-        kind: 'regrid',
-        input_uri: inputUri,
-        output_uri: outputUri,
-        params: { method, dst_grid: dstGrid },
-      })
-      submitted.push({ jobId, method })
-    }
-
-    // Debounced: one worker-execution request per batch (not per job), so a
-    // 3-method comparison doesn't launch 3 concurrent Cloud Run Job
-    // executions. Best-effort — see triggerWorkerRun() for why this may 403
-    // until the SA's IAM grant is confirmed. Never blocks the response: jobs
-    // are already submitted and will run whenever the worker next executes,
-    // triggered or not.
-    const workerTrigger = await triggerWorkerRun()
-    if (!workerTrigger.triggered) {
-      console.warn(`omni-gridder submit: worker not auto-triggered (${workerTrigger.reason})`)
-    }
-
-    return NextResponse.json({
-      jobs: submitted,
-      inputUri,
-      workerTriggered: workerTrigger.triggered,
+  // Admin-side budget policy (authn + rate class is the route's job, not the
+  // shared proxy's). A submit triggers real Cloud Run job pickup — cheap, but
+  // not free, and not something an admin page should let run away with even
+  // though it's passphrase-gated. A comparison batch is up to 3 jobs in one
+  // call, so the per-request budget is tighter than the old single-job limit:
+  // one comparison (or a few singles) per 2-minute window per IP. Runs after
+  // validation (inside submitRegridBatch), so an invalid request never burns
+  // budget — see the checkBudget contract.
+  const outcome = await submitRegridBatch(body, async () => {
+    const ip =
+      request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
+      request.headers.get('x-real-ip') ||
+      'unknown'
+    const limit = await rateLimit(ip, {
+      limit: 2,
+      windowMs: 2 * 60 * 1000,
+      prefix: 'og-demo-submit',
     })
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    console.error(`omni-gridder submit failed: ${message}`)
-    return NextResponse.json({ error: `Job submission failed: ${message}` }, { status: 500 })
-  }
+    if (limit.success) return null
+    return {
+      status: 429,
+      error: 'Rate limit exceeded — wait before submitting another demo job',
+      headers: { 'Retry-After': limit.retryAfterSeconds.toString() },
+    }
+  })
+
+  if (!outcome.ok) return proxyErrorResponse(outcome)
+  return NextResponse.json(outcome.data)
 }

--- a/src/lib/omni-gridder-proxy.ts
+++ b/src/lib/omni-gridder-proxy.ts
@@ -1,0 +1,394 @@
+import { NextResponse } from 'next/server'
+import { allowedInputUris } from './og-demo-inputs'
+import {
+  getJobStatus,
+  submitJob,
+  triggerWorkerRun,
+  type OmniGridderJobStatus,
+} from './omni-gridder-client'
+
+// Shared, framework-light omni-gridder proxy logic — the single home for the
+// og-server orchestration that previously lived inline in the three
+// /api/admin/omni-gridder/* route handlers (submit / status / download).
+//
+// Split of responsibilities (SRP): this module owns "talk to og-server
+// correctly, validate every client-supplied value, and normalize every
+// failure into a status+message"; the ROUTE that calls it owns "who is
+// allowed, and how much" (authn + rate class / budget). That boundary is what
+// lets a future PUBLIC showcase route (issue #89) reuse every function here
+// unchanged while enforcing a stricter per-visitor budget — see the
+// `checkBudget` extension point on submitRegridBatch(). No budget/rate logic
+// lives in this module by design.
+
+const GCS_STAGING_BUCKET = process.env.OG_GCS_STAGING_BUCKET
+
+// ---- Error normalization ---------------------------------------------------
+
+/**
+ * A normalized proxy failure: the HTTP status and message a route should
+ * return, plus any response headers (e.g. Retry-After on a 429). Every
+ * function below returns one of these instead of throwing, so both the admin
+ * routes and a future public route render failures identically.
+ */
+export interface ProxyError {
+  status: number
+  error: string
+  headers?: Record<string, string>
+}
+
+export type ProxyOutcome<T> = { ok: true; data: T } | ({ ok: false } & ProxyError)
+
+/** Render a ProxyError as the JSON error response both route families use. */
+export function proxyErrorResponse(err: ProxyError): NextResponse {
+  return NextResponse.json({ error: err.error }, { status: err.status, headers: err.headers })
+}
+
+// ---- Submit ----------------------------------------------------------------
+
+export type RegridMethod = 'nearest' | 'bilinear' | 'conservative'
+const VALID_METHODS: RegridMethod[] = ['nearest', 'bilinear', 'conservative']
+
+export interface SubmitRequestBody {
+  /** One or more methods to run against the same input+grid. Defaults to ['bilinear']. */
+  methods?: string[]
+  /** Must be one of the server allowlist; defaults to the first allowlisted URI. */
+  inputUri?: string
+}
+
+export interface SubmittedJob {
+  jobId: string
+  method: RegridMethod
+}
+
+export interface SubmitResult {
+  jobs: SubmittedJob[]
+  inputUri: string
+  workerTriggered: boolean
+}
+
+/**
+ * Optional policy hook invoked AFTER request validation but BEFORE any job is
+ * submitted to og-server — the exact point at which a caller enforces its own
+ * budget / rate class. Return a ProxyError to short-circuit submission with
+ * that status+message (+ optional headers); return null (or omit the hook) to
+ * proceed.
+ *
+ * This is the extension point for the future public #89 showcase route: the
+ * admin route passes an IP-based rate limit here, and a public route will pass
+ * a stricter per-visitor budget / rate class WITHOUT touching this module.
+ * Ordering is deliberate — a request that fails validation never consumes
+ * budget, matching the original admin route's behavior.
+ */
+export type BudgetCheck = () => Promise<ProxyError | null>
+
+// 0.5° CONUS grid, generated server-side (never client-supplied — same SSRF/
+// resource-exhaustion reasoning as the input allowlist: an arbitrary dst_grid
+// from the client could ask og-server to materialize an enormous output
+// array). lat 24..49 step 0.5 = 51 points; lon -125..-66 step 0.5 = 119 points.
+function buildConusGrid(): { lat: number[]; lon: number[] } {
+  const lat: number[] = []
+  for (let i = 0; i <= 50; i++) lat.push(Math.round((24 + i * 0.5) * 1000) / 1000)
+  const lon: number[] = []
+  for (let i = 0; i <= 118; i++) lon.push(Math.round((-125 + i * 0.5) * 1000) / 1000)
+  return { lat, lon }
+}
+
+/**
+ * Validate a submit request, optionally enforce a caller-supplied budget, then
+ * submit one regrid job per (deduped, allowlisted) method and best-effort
+ * trigger the worker. Talks to external systems (WIF token minting, og-server,
+ * Cloud Run Admin API); any throw past validation is caught and normalized to
+ * a 500 ProxyError so a route never surfaces Next's HTML 500 page (which is
+ * exactly how a missing/stale env var once hid from us in production).
+ */
+export async function submitRegridBatch(
+  body: SubmitRequestBody,
+  checkBudget?: BudgetCheck,
+): Promise<ProxyOutcome<SubmitResult>> {
+  if (!GCS_STAGING_BUCKET) {
+    return { ok: false, status: 500, error: 'OG_GCS_STAGING_BUCKET is not set' }
+  }
+
+  const requestedMethods =
+    body.methods && body.methods.length > 0 ? body.methods : ['bilinear']
+  // Dedupe before validation/submission — {methods:["bilinear","bilinear"]}
+  // would otherwise submit the same jobId twice and schedule duplicate polling
+  // for what is really a single job. Preserve request order.
+  const methods = [...new Set(requestedMethods)] as string[]
+  const invalidMethod = methods.find((m) => !VALID_METHODS.includes(m as RegridMethod))
+  if (invalidMethod) {
+    return {
+      ok: false,
+      status: 400,
+      error: `Invalid method "${invalidMethod}" — must be one of ${VALID_METHODS.join(', ')}`,
+    }
+  }
+  if (methods.length > VALID_METHODS.length) {
+    return { ok: false, status: 400, error: 'Too many methods requested' }
+  }
+
+  const allowlist = allowedInputUris()
+  const inputUri = body.inputUri ?? allowlist[0]
+  if (!allowlist.includes(inputUri)) {
+    return { ok: false, status: 400, error: 'input URI is not in the server allowlist' }
+  }
+
+  // Budget / rate-class gate: after validation, before any external call — an
+  // invalid request must never consume budget.
+  if (checkBudget) {
+    const budgetError = await checkBudget()
+    if (budgetError) return { ok: false, ...budgetError }
+  }
+
+  const dstGrid = buildConusGrid()
+  const batchSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+
+  try {
+    const submitted: SubmittedJob[] = []
+    for (const method of methods as RegridMethod[]) {
+      const jobId = `demo-${batchSuffix}-${method}`
+      const outputUri = `gs://${GCS_STAGING_BUCKET}/demo/regrid/${jobId}/output.nc`
+      await submitJob({
+        job_id: jobId,
+        processor_type: 'regrid',
+        kind: 'regrid',
+        input_uri: inputUri,
+        output_uri: outputUri,
+        params: { method, dst_grid: dstGrid },
+      })
+      submitted.push({ jobId, method })
+    }
+
+    // Debounced: one worker-execution request per batch (not per job), so a
+    // 3-method comparison doesn't launch 3 concurrent Cloud Run Job
+    // executions. Best-effort — see triggerWorkerRun() for why this may 403
+    // until the SA's IAM grant is confirmed. Never blocks the response: jobs
+    // are already submitted and will run whenever the worker next executes.
+    const workerTrigger = await triggerWorkerRun()
+    if (!workerTrigger.triggered) {
+      console.warn(`omni-gridder submit: worker not auto-triggered (${workerTrigger.reason})`)
+    }
+
+    return {
+      ok: true,
+      data: { jobs: submitted, inputUri, workerTriggered: workerTrigger.triggered },
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`omni-gridder submit failed: ${message}`)
+    return { ok: false, status: 500, error: `Job submission failed: ${message}` }
+  }
+}
+
+// ---- Status (+ chained plot) -----------------------------------------------
+
+const PLOT_SUFFIX = '-plot'
+
+/** Request-derived options for a status poll — parsed by the caller from the URL. */
+export interface StatusOptions {
+  /** Whether this poll should chain a Plot job once the regrid succeeds. */
+  chainPlot: boolean
+  /** Optional before/after panel input URI (re-validated against the allowlist). */
+  compare: string | null
+  /** Optional comma-separated regrid job ids for a multi-panel comparison plot. */
+  panels: string | null
+}
+
+export type StatusResult = OmniGridderJobStatus & { nextJobId?: string }
+
+/**
+ * Fetch a job's status and, when the caller opts in via chainPlot, chain a
+ * single Plot job once the regrid stage succeeds.
+ *
+ * Deliberately does NOT wrap getJobStatus in try/catch: a transport failure
+ * here should propagate (the admin route returned Next's 500 for it), unlike
+ * the download path which normalizes lookup failures to a 502.
+ */
+export async function getRegridJobStatus(
+  jobId: string,
+  options: StatusOptions,
+): Promise<ProxyOutcome<StatusResult>> {
+  if (!GCS_STAGING_BUCKET) {
+    return { ok: false, status: 500, error: 'OG_GCS_STAGING_BUCKET is not set' }
+  }
+
+  const status = await getJobStatus(jobId)
+  if (!status) {
+    return { ok: false, status: 404, error: 'Job not found' }
+  }
+
+  // Once the regrid stage succeeds, chain a Plot job reading its output. Job
+  // IDs are unique-insert-only in og-server's job store (409 on duplicate), so
+  // re-submitting on every subsequent poll that lands after this transition is
+  // harmless — submitJob() already treats 409 as success. The Plot job's own
+  // gs:// input is reconstructed from the same bucket/jobId convention used at
+  // submit time, not parsed back out of the (signed, HTTPS) result_uri
+  // og-server returns — workers need a raw gs:// URI to read via DataReader,
+  // not a browser-facing signed download link.
+  //
+  // In comparison mode three regrid jobs poll independently; only ONE (the
+  // caller's designated primary) passes chainPlot, so exactly one plot renders.
+  const isRegridJob = status.processor_type === 'regrid' && !jobId.endsWith(PLOT_SUFFIX)
+  if (options.chainPlot && isRegridJob && status.status === 'succeeded') {
+    // Optional before/after panel: only honored if the compare URI is in the
+    // same server-side allowlist the submit path enforces — the plot worker
+    // reads this URI from GCS, so it must never be client-arbitrary.
+    const compareUri =
+      options.compare && allowedInputUris().includes(options.compare)
+        ? options.compare
+        : undefined
+
+    // Comparison mode: panels=<jobId,jobId,...> chains ONE multi-panel plot
+    // (input + every method's output). Only job IDs are accepted — each is
+    // strictly validated and its output URI reconstructed from OUR bucket/jobId
+    // convention, so the client never supplies a URI. Invalid ids are a loud
+    // 400, not a silent drop: a typo'd panel list should never quietly render
+    // fewer methods.
+    let panelUris: { uri: string; label: string }[] | undefined
+    if (options.panels) {
+      const ids = options.panels.split(',').map((s) => s.trim()).filter(Boolean)
+      const idPattern = /^[a-z][a-z0-9-]{0,58}-(nearest|bilinear|conservative|ewa)$/
+      if (ids.length === 0 || ids.length > 4 || ids.some((id) => !idPattern.test(id))) {
+        return { ok: false, status: 400, error: 'panels must be 1-4 valid regrid job ids' }
+      }
+      panelUris = ids.map((id) => {
+        const method = id.slice(id.lastIndexOf('-') + 1)
+        return {
+          uri: `gs://${GCS_STAGING_BUCKET}/demo/regrid/${id}/output.nc`,
+          label: method.charAt(0).toUpperCase() + method.slice(1),
+        }
+      })
+    }
+
+    const plotJobId = `${jobId}${PLOT_SUFFIX}`
+    await submitJob({
+      job_id: plotJobId,
+      processor_type: 'plot',
+      kind: 'plot',
+      input_uri: `gs://${GCS_STAGING_BUCKET}/demo/regrid/${jobId}/output.nc`,
+      output_uri: `gs://${GCS_STAGING_BUCKET}/demo/regrid/${jobId}/plot.png`,
+      params: {
+        variable: 'HGT',
+        title: 'Agentic OG — Method Comparison Demo',
+        colormap: 'RdYlBu_r',
+        ...(compareUri ? { compare_uri: compareUri } : {}),
+        ...(panelUris ? { panel_uris: panelUris } : {}),
+      },
+    })
+    return { ok: true, data: { ...status, nextJobId: plotJobId } }
+  }
+
+  return { ok: true, data: status }
+}
+
+// ---- Download (signed-URL proxy) -------------------------------------------
+
+// Job IDs are our own generated strings (see submitRegridBatch /
+// getRegridJobStatus), always lowercase-alnum-hyphen and always ending in
+// "-plot" for the chained plot job this path serves. Reject anything else
+// before it ever reaches getJobStatus.
+const PLOT_JOB_ID_RE = /^[a-z][a-z0-9-]{0,62}-plot$/
+
+export interface DownloadSuccess {
+  /** The upstream (signed-URL) body to stream back to the client. */
+  body: ReadableStream<Uint8Array>
+  contentType: string
+  /** Suggested attachment filename (no directory, includes extension). */
+  filename: string
+}
+
+/**
+ * Resolve a plot job to its signed GCS result URL and stream the bytes back.
+ *
+ * Looked up by job id, not by URL: the client never sees or holds the signed
+ * bearer URL. We resolve job -> status -> result_uri via getJobStatus(), and
+ * only THEN apply the host/path allowlist below — defense in depth, not the
+ * primary authority (og-server is the only thing that ever produces a value
+ * here, and it only ever returns signed URLs). Fetching server-side also
+ * sidesteps the cross-origin <a download> limitation (storage.googleapis.com
+ * ignores the download attribute and serves no CORS headers for a blob fetch).
+ */
+export async function downloadPlot(
+  jobId: string | null,
+): Promise<ProxyOutcome<DownloadSuccess>> {
+  if (!GCS_STAGING_BUCKET) {
+    return { ok: false, status: 500, error: 'OG_GCS_STAGING_BUCKET is not set' }
+  }
+
+  if (!jobId || !PLOT_JOB_ID_RE.test(jobId)) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'job query param required — must be a plot job id ending in "-plot"',
+    }
+  }
+
+  let status
+  try {
+    status = await getJobStatus(jobId)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, status: 502, error: `Job lookup failed: ${message}` }
+  }
+  if (!status) {
+    return { ok: false, status: 404, error: 'Job not found' }
+  }
+  if (status.status !== 'succeeded' || !status.result_uri) {
+    return {
+      ok: false,
+      status: 409,
+      error: `Job is not ready for download (status: ${status.status})`,
+    }
+  }
+
+  let target: URL
+  try {
+    target = new URL(status.result_uri)
+  } catch {
+    return { ok: false, status: 502, error: 'og-server returned an invalid result URL' }
+  }
+  const validHost = target.hostname === 'storage.googleapis.com'
+  const validPath = target.pathname.startsWith(`/${GCS_STAGING_BUCKET}/`)
+  if (target.protocol !== 'https:' || !validHost || !validPath) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'result URL must be a signed storage.googleapis.com link for the demo bucket',
+    }
+  }
+
+  let upstream: Response
+  try {
+    upstream = await fetch(target.toString(), {
+      // A redirect off the allowlisted host must fail outright, never be
+      // followed — 'follow' would let a compromised/misconfigured upstream hop
+      // us to an arbitrary origin after the guard above already passed.
+      redirect: 'error',
+      signal: AbortSignal.timeout(20_000),
+    })
+  } catch (err) {
+    // fetch() throws (doesn't resolve to a non-ok Response) on DNS failure,
+    // network errors, timeout, and a blocked redirect — all of those must come
+    // back as JSON, not surface as Next's HTML 500 page.
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, status: 502, error: `Upstream fetch failed: ${message}` }
+  }
+
+  if (!upstream.ok || !upstream.body) {
+    return {
+      ok: false,
+      status: 502,
+      error: `upstream fetch failed (${upstream.status}) — the signed URL may have expired; re-run the job`,
+    }
+  }
+
+  const stamp = new Date().toISOString().slice(0, 16).replace(/[:T]/g, '-')
+  return {
+    ok: true,
+    data: {
+      body: upstream.body,
+      contentType: upstream.headers.get('content-type') ?? 'image/png',
+      filename: `og-method-comparison-${stamp}.png`,
+    },
+  }
+}


### PR DESCRIPTION
## Increment 1 of #89 — DRY shared-library extraction only

This is a **behavior-preserving pure refactor**, the first increment of #89 (Public omni-gridder showcase). It addresses design-review requirement #1: *"Base on the existing implementation — extract shared proxy/lib from `/api/admin/omni-gridder/*`."*

**Scope discipline:** No public page, no public API routes, no GCP infra, no new dependencies. Just the extraction.

### What changed
- **New:** `src/lib/omni-gridder-proxy.ts` — the single home for the og-server proxy orchestration (submit / status+plot-chaining / download) that previously lived inline in the three route handlers. Every function returns a normalized `ProxyOutcome<T>` (`ok` data or `status`+`error`+optional `headers`) instead of building `NextResponse` directly, so any caller renders success and failure identically.
- **Refactored** all three `/api/admin/omni-gridder/*` routes to call the shared module. Each route now owns only what is genuinely route-specific: admin auth (`isAdmin`) and, for submit, the IP rate-limit policy.

### SRP boundary
- Shared module owns: talking to og-server correctly, validating every client-supplied value (methods, input-URI allowlist, panel ids, signed-URL host/path), and normalizing every failure.
- Each route owns: **who** is allowed (authn) and **how much** (rate class / budget).

### Extension point for the future public route (no budget logic implemented here)
`submitRegridBatch(body, checkBudget?)` accepts an optional `checkBudget` policy hook, invoked **after validation, before any og-server call** — so an invalid request never consumes budget (exactly matching the prior admin behavior). The admin route passes its existing IP rate-limit here; the future public #89 route will pass a stricter per-visitor budget/rate class **without touching this module**. No budget/rate logic lives in the shared module by design.

### What is shared now
- Submit: CONUS grid generation, method dedupe+validation, input-URI allowlist enforcement, batch job submission, best-effort worker trigger.
- Status: job lookup, single-plot chaining gate, `compare` allowlist re-validation, `panels` multi-panel validation + URI reconstruction.
- Download: plot-job-id validation, job→result_uri resolution, signed-URL host/path/protocol allowlisting, redirect-safe upstream fetch, attachment streaming.

### Verification
- `node_modules/.bin/tsc --noEmit` → clean (exit 0)
- `eslint` on changed files → clean (exit 0)
- All **19** existing `tests/integration/omni-gridder-api.test.ts` cases pass unchanged — behavior is identical.

> Draft — GitHub Copilot auto-reviews every PR; do not merge until its review is triaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)