### PR TITLE
feat(showcase): omni-gridder dataset catalog, comparison UI, live-job e2e (#89)

### DIFF
--- a/src/app/admin/omni-gridder/page.tsx
+++ b/src/app/admin/omni-gridder/page.tsx
@@ -94,6 +94,51 @@ interface TimelineEntry {
   label: string
 }
 
+/**
+ * One completed run, kept so a later run of the same (dataset, method) can be
+ * compared against it.
+ *
+ * This is what makes the weight-reuse claim demonstrable rather than asserted.
+ * The engine separates weight GENERATION (the expensive, accuracy-gated step)
+ * from weight APPLICATION (the cheap, parity-gated one); the visible
+ * consequence is that the second run of an identical job skips generation
+ * entirely. A cache-hit column alone does not show that — it takes two runs
+ * side by side, and both have to be ones the viewer actually watched.
+ */
+interface RunObservation {
+  wallClockMs: number
+  cacheHit: boolean | null
+}
+
+/** Session-scoped run history, keyed `datasetId::method`. */
+type RunHistory = Record<string, RunObservation[]>
+
+function historyKey(datasetId: string, method: RegridMethod): string {
+  return `${datasetId}::${method}`
+}
+
+/**
+ * The first cold run and the first subsequent warm run for one key, or `null`
+ * when the session has not observed both.
+ *
+ * Returns `null` rather than a partial answer on purpose: a speedup figure
+ * derived from one measurement is not a speedup figure. Until both exist the
+ * panel says how to produce the second one.
+ */
+function coldWarmPair(
+  observations: RunObservation[] | undefined,
+): { cold: RunObservation; warm: RunObservation } | null {
+  if (!observations) return null
+  const coldIndex = observations.findIndex((o) => o.cacheHit === false)
+  if (coldIndex === -1) return null
+  const warm = observations.slice(coldIndex + 1).find((o) => o.cacheHit === true)
+  return warm ? { cold: observations[coldIndex], warm } : null
+}
+
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${ms} ms` : `${(ms / 1000).toFixed(1)} s`
+}
+
 const POLL_INTERVAL_MS = 3000
 
 function idleRow(method: RegridMethod): MethodRow {
@@ -153,6 +198,97 @@ function ProvenanceBadge({ kind }: { kind: Provenance }) {
   )
 }
 
+/**
+ * The speed story, told with the viewer's own runs.
+ *
+ * ADR #290's keystone separation — weight GENERATION (expensive, oracle-gated)
+ * from weight APPLICATION (cheap, parity-gated) — has one consequence a
+ * non-specialist can see: rerun the same job and the expensive step vanishes,
+ * because the operator is already in the cache. This panel shows that as a
+ * cold/warm pair measured in this browser session, or tells the viewer how to
+ * produce one. It never substitutes a recorded benchmark for the pair: a
+ * speed claim on this page is either measured live or absent.
+ *
+ * Wall clock here includes queue + polling latency, and says so — the honest
+ * comparison is end-to-end time for the same job, not a flattering subset.
+ */
+function WeightReusePanel({
+  dataset,
+  allowedMethods,
+  runHistory,
+}: {
+  dataset: DatasetView
+  allowedMethods: RegridMethod[]
+  runHistory: RunHistory
+}) {
+  const pairs = allowedMethods
+    .map((method) => ({
+      method,
+      pair: coldWarmPair(runHistory[historyKey(dataset.id, method)]),
+    }))
+    .filter((p): p is { method: RegridMethod; pair: NonNullable<ReturnType<typeof coldWarmPair>> } =>
+      p.pair !== null,
+    )
+
+  return (
+    <div className="mb-10">
+      <h2 className="font-mono text-[11px] uppercase tracking-wider text-gray-500 mb-3">
+        Weight reuse · {dataset.label}
+      </h2>
+      {pairs.length === 0 ? (
+        <p className="text-sm text-gray-500">
+          Run the same method twice on this dataset to measure it: the first run generates the
+          remap operator (the expensive, accuracy-gated step), the second finds it in the cache
+          and only applies it. Both runs are timed in this session — no recorded benchmark stands
+          in for the pair.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[560px] border-collapse text-sm">
+            <thead>
+              <tr className="text-left text-gray-500 font-mono text-[11px] uppercase tracking-wider">
+                <th className="border-b border-white/10 pb-2 pr-4">Method</th>
+                <th className="border-b border-white/10 pb-2 pr-4">Cold (generates weights)</th>
+                <th className="border-b border-white/10 pb-2 pr-4">Warm (reuses weights)</th>
+                <th className="border-b border-white/10 pb-2 pr-4">Speedup</th>
+                <th className="border-b border-white/10 pb-2">Provenance</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pairs.map(({ method, pair }) => (
+                <tr key={method} className="text-gray-300">
+                  <td className="border-b border-white/5 py-2 pr-4 font-medium text-white">
+                    {METHOD_LABELS[method]}
+                  </td>
+                  <td className="border-b border-white/5 py-2 pr-4 font-mono">
+                    {formatDuration(pair.cold.wallClockMs)}
+                  </td>
+                  <td className="border-b border-white/5 py-2 pr-4 font-mono">
+                    {formatDuration(pair.warm.wallClockMs)}
+                  </td>
+                  <td className="border-b border-white/5 py-2 pr-4 font-mono text-emerald-300">
+                    {pair.warm.wallClockMs > 0
+                      ? `${(pair.cold.wallClockMs / pair.warm.wallClockMs).toFixed(1)}×`
+                      : '—'}
+                  </td>
+                  <td className="border-b border-white/5 py-2">
+                    <ProvenanceBadge kind="live" />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="mt-2 text-xs text-gray-500">
+            End-to-end wall clock, including queue and polling latency — the same overhead in both
+            columns, so the difference is the generation step. Cold/warm classification comes from
+            the engine&apos;s own <code>weight_cache_hit</code> diagnostic, not from run order.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
 export default function OmniGridderDemoPage() {
   const [datasets, setDatasets] = useState<DatasetView[]>([])
   const [selectedDatasetId, setSelectedDatasetId] = useState<string | null>(null)
@@ -170,6 +306,14 @@ export default function OmniGridderDemoPage() {
   const [plotJobId, setPlotJobId] = useState<string | null>(null)
   const [globalError, setGlobalError] = useState<string | null>(null)
   const [workerTriggered, setWorkerTriggered] = useState<boolean | null>(null)
+  const [runHistory, setRunHistory] = useState<RunHistory>({})
+  // The dataset a run was submitted UNDER, not whatever is selected when it
+  // finishes. A job takes seconds and the picker stays live throughout, so
+  // reading `selectedDatasetId` at completion time would file a GOES run under
+  // whichever dataset the viewer clicked while waiting.
+  const runDatasetIdRef = useRef<string | null>(null)
+  /** Client-side submit time per method, consumed once when that run completes. */
+  const runStartRef = useRef<Map<RegridMethod, number>>(new Map())
   const pollTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
   // Input URI from the last submit response — passed back on the chainPlot
   // poll so the server can chain a before/after plot (server re-validates
@@ -246,6 +390,31 @@ export default function OmniGridderDemoPage() {
   const updateRow = useCallback((method: RegridMethod, patch: Partial<MethodRow>) => {
     setRows((prev) => ({ ...prev, [method]: { ...prev[method], ...patch } }))
   }, [])
+
+  /**
+   * Appends one completed regrid to the session's run history.
+   *
+   * Start times come from `runStartRef`, not from the `rows` state. This runs
+   * inside a poll callback that may have closed over a stale render, and a
+   * wrong start time would silently produce a wrong speedup — the exact kind
+   * of number this panel exists to make trustworthy. A ref is also the only
+   * place it can be read without doing state updates inside another updater,
+   * which StrictMode would double-invoke into a double-counted run.
+   */
+  const recordRun = useCallback(
+    (method: RegridMethod, completedAt: number, cacheHit: boolean | null) => {
+      const datasetId = runDatasetIdRef.current
+      const submittedAt = runStartRef.current.get(method)
+      if (!datasetId || submittedAt === undefined) return
+      // Consume it, so a chained plot poll or a duplicate terminal status
+      // cannot append the same run twice.
+      runStartRef.current.delete(method)
+      const key = historyKey(datasetId, method)
+      const observation: RunObservation = { wallClockMs: completedAt - submittedAt, cacheHit }
+      setRunHistory((h) => ({ ...h, [key]: [...(h[key] ?? []), observation] }))
+    },
+    [],
+  )
 
   // Plain function, not useCallback: it recurses on itself via setTimeout,
   // which the React Compiler's lint rules flag as unsafe inside a hook
@@ -331,11 +500,15 @@ export default function OmniGridderDemoPage() {
         updateRow(method, { status: 'succeeded' })
         return
       }
+      const completedAt = Date.now()
       updateRow(method, {
         status: data.nextJobId ? 'plotting' : 'succeeded',
-        completedAt: Date.now(),
+        completedAt,
         diagnostics: data.diagnostics,
       })
+      // Record the REGRID job only. A chained plot job is separate work and
+      // its wall clock has nothing to say about weight reuse.
+      recordRun(method, completedAt, data.diagnostics?.weight_cache_hit ?? null)
       if (data.nextJobId) {
         log(`Chained plot job ${data.nextJobId} (from ${method})`)
         setPlotJobId(data.nextJobId)
@@ -427,6 +600,8 @@ export default function OmniGridderDemoPage() {
       }
 
       const submittedAt = Date.now()
+      runDatasetIdRef.current = selectedDatasetId
+      for (const { method } of data.jobs) runStartRef.current.set(method, submittedAt)
       const comparisonMode = data.jobs.length > 1
       // Comparison mode chains ONE multi-panel plot only after ALL methods
       // succeed (see the succeeded branch in pollJob) — so no per-method
@@ -451,9 +626,14 @@ export default function OmniGridderDemoPage() {
       }
     },
     // pollJob is a plain function (not memoized) recreated every render —
-    // intentionally omitted from deps, see its own definition above.
+    // intentionally omitted from deps, see its own definition above. The
+    // disable is ONLY for pollJob: every state value the closure reads must
+    // still be listed, because this suppression previously hid a real bug —
+    // `selectedDatasetId` was omitted, so the memoized closure kept its
+    // first-render value (null, the catalog loads async) and every submit
+    // POSTed `datasetId: null` regardless of the picker.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [log, stopAllPolling, updateRow],
+    [log, stopAllPolling, updateRow, selectedDatasetId, primaryMethod],
   )
 
   const runSingle = useCallback(() => runJobs([selectedMethod]), [runJobs, selectedMethod])
@@ -717,6 +897,14 @@ export default function OmniGridderDemoPage() {
               </tbody>
             </table>
           </div>
+        )}
+
+        {selectedDataset && (
+          <WeightReusePanel
+            dataset={selectedDataset}
+            allowedMethods={allowedMethods}
+            runHistory={runHistory}
+          />
         )}
 
         <div className="grid gap-10 md:grid-cols-2">

--- a/src/app/admin/omni-gridder/page.tsx
+++ b/src/app/admin/omni-gridder/page.tsx
@@ -549,6 +549,13 @@ export default function OmniGridderDemoPage() {
 
   const runJobs = useCallback(
     async (methods: RegridMethod[]) => {
+      // The catalog loads async; a click before it lands would submit
+      // datasetId: null and let the server silently default. Refuse instead —
+      // run history and the weight-reuse panel key off the dataset id.
+      if (!selectedDatasetId) {
+        setGlobalError('Catalog is still loading — select a dataset first')
+        return
+      }
       stopAllPolling()
       setGlobalError(null)
       setPlotUrl(null)
@@ -591,6 +598,7 @@ export default function OmniGridderDemoPage() {
       const data = (await res.json()) as {
         jobs: { jobId: string; method: RegridMethod }[]
         inputUri: string
+        datasetId: string
         workerTriggered: boolean
       }
       inputUriRef.current = data.inputUri ?? ''
@@ -600,7 +608,9 @@ export default function OmniGridderDemoPage() {
       }
 
       const submittedAt = Date.now()
-      runDatasetIdRef.current = selectedDatasetId
+      // Record history under what the SERVER says ran — the resolved id in the
+      // response — not the client-side selection it was derived from.
+      runDatasetIdRef.current = data.datasetId ?? selectedDatasetId
       for (const { method } of data.jobs) runStartRef.current.set(method, submittedAt)
       const comparisonMode = data.jobs.length > 1
       // Comparison mode chains ONE multi-panel plot only after ALL methods

--- a/src/app/admin/omni-gridder/page.tsx
+++ b/src/app/admin/omni-gridder/page.tsx
@@ -1,19 +1,59 @@
 'use client'
 
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-type RegridMethod = 'nearest' | 'bilinear' | 'conservative'
-const METHODS: RegridMethod[] = ['nearest', 'bilinear', 'conservative']
+type RegridMethod = 'nearest' | 'bilinear' | 'conservative' | 'ewa'
+// No local list of "all methods": the compatibility matrix renders whatever the
+// server sends for the selected dataset. A second enumeration here would be a
+// place for the page's idea of the method set to drift from the engine's.
 const METHOD_LABELS: Record<RegridMethod, string> = {
-  nearest: 'Nearest neighbor',
+  nearest: 'Nearest neighbour',
   bilinear: 'Bilinear',
   conservative: 'Conservative',
+  ewa: 'EWA (swath)',
 }
 
-// Bilinear is the "primary" method whose regrid result gets plotted — it's
-// the one method present in both single mode and every comparison run, so
-// the map panel never has to pick between three plots.
-const PRIMARY_METHOD: RegridMethod = 'bilinear'
+/**
+ * Which methods are valid depends on the DATASET, not on the app.
+ *
+ * The primary method — the one whose result gets plotted when several run —
+ * used to be the constant `bilinear`. That is not merely a style choice once
+ * satellite datasets exist: bilinear is invalid on a swath source, so a fixed
+ * primary would ask for a plot of a job that was refused and never submitted.
+ * It now comes from the selected dataset's first allowed method.
+ */
+interface MethodAvailability {
+  method: RegridMethod
+  allowed: boolean
+  reason: string | null
+}
+
+interface DatasetView {
+  id: string
+  label: string
+  source: string
+  variable: string
+  units: string
+  geometry: 'rectilinear' | 'geostationary-swath'
+  nativeResolution: string
+  demonstrates: string
+  targetSummary: string
+  targetCrsLabel: string
+  destinationCells: number | null
+  methods: MethodAvailability[]
+  primaryMethod: RegridMethod
+}
+
+/**
+ * Where a number on this page came from.
+ *
+ * Every figure the showcase displays is either measured by the run you just
+ * watched, or a recorded result from a verification that happened elsewhere.
+ * Those are not the same claim, and a page that renders them identically is
+ * quietly overstating one of them. The badge is deliberately visible rather
+ * than a footnote.
+ */
+type Provenance = 'live' | 'verified'
 
 type RowStatus = 'idle' | 'submitting' | 'queued' | 'processing' | 'plotting' | 'succeeded' | 'failed'
 
@@ -87,12 +127,42 @@ function formatNumber(value: number | null): string {
   return value === null ? '—' : value.toString()
 }
 
+/**
+ * Marks whether a figure was measured by the run you just watched, or is a
+ * recorded result from a verification performed elsewhere.
+ *
+ * Visible rather than a footnote, on purpose. A page that renders a live
+ * measurement and a recorded benchmark in the same style is overstating one of
+ * them, and the reader has no way to tell which.
+ */
+function ProvenanceBadge({ kind }: { kind: Provenance }) {
+  const live = kind === 'live'
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider ${
+        live ? 'bg-emerald-500/15 text-emerald-300' : 'bg-sky-500/15 text-sky-300'
+      }`}
+      title={
+        live
+          ? 'Measured by this run, on this hardware'
+          : 'Recorded result from a verification performed elsewhere — not exercised by this demo'
+      }
+    >
+      {live ? 'live run' : 'recorded verification'}
+    </span>
+  )
+}
+
 export default function OmniGridderDemoPage() {
+  const [datasets, setDatasets] = useState<DatasetView[]>([])
+  const [selectedDatasetId, setSelectedDatasetId] = useState<string | null>(null)
+  const [catalogError, setCatalogError] = useState<string | null>(null)
   const [selectedMethod, setSelectedMethod] = useState<RegridMethod>('bilinear')
   const [rows, setRows] = useState<Record<RegridMethod, MethodRow>>({
     nearest: idleRow('nearest'),
     bilinear: idleRow('bilinear'),
     conservative: idleRow('conservative'),
+    ewa: idleRow('ewa'),
   })
   const [activeMethods, setActiveMethods] = useState<RegridMethod[]>([])
   const [timeline, setTimeline] = useState<TimelineEntry[]>([])
@@ -114,6 +184,55 @@ export default function OmniGridderDemoPage() {
   const panelJobIdsRef = useRef<string[]>([])
   const succeededJobsRef = useRef<Set<string>>(new Set())
   const panelChainFiredRef = useRef(false)
+
+  // The catalog comes from the server rather than being duplicated here: the
+  // compatibility matrix the page renders and the one the proxy ENFORCES must
+  // be the same fact, or the UI will offer a combination the server refuses.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch('/api/admin/omni-gridder/datasets')
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = (await res.json()) as { datasets: DatasetView[] }
+        if (cancelled) return
+        if (!Array.isArray(data.datasets) || data.datasets.length === 0) {
+          setCatalogError('The showcase catalog is empty')
+          return
+        }
+        setDatasets(data.datasets)
+        setSelectedDatasetId((current) => current ?? data.datasets[0].id)
+      } catch (err) {
+        if (!cancelled) {
+          setCatalogError(err instanceof Error ? err.message : 'Could not load the dataset catalog')
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const selectedDataset = useMemo(
+    () => datasets.find((d) => d.id === selectedDatasetId) ?? null,
+    [datasets, selectedDatasetId],
+  )
+  const allowedMethods = useMemo(
+    () => selectedDataset?.methods.filter((m) => m.allowed).map((m) => m.method) ?? [],
+    [selectedDataset],
+  )
+  const primaryMethod: RegridMethod = selectedDataset?.primaryMethod ?? 'bilinear'
+
+  // Keep the single-method selection valid when the dataset changes. Silently
+  // leaving `bilinear` selected after switching to a satellite would submit a
+  // combination the server refuses — the user would see an error for a choice
+  // the UI made on their behalf.
+  useEffect(() => {
+    if (!selectedDataset) return
+    if (!allowedMethods.includes(selectedMethod)) {
+      setSelectedMethod(selectedDataset.primaryMethod)
+    }
+  }, [selectedDataset, allowedMethods, selectedMethod])
 
   const log = useCallback((label: string) => {
     setTimeline((prev) => [...prev, { at: Date.now(), label }])
@@ -238,10 +357,10 @@ export default function OmniGridderDemoPage() {
       ) {
         panelChainFiredRef.current = true
         const primary =
-          panelJobIdsRef.current.find((id) => id.endsWith(`-${PRIMARY_METHOD}`)) ??
+          panelJobIdsRef.current.find((id) => id.endsWith(`-${primaryMethod}`)) ??
           panelJobIdsRef.current[0]
         log('All methods succeeded — chaining multi-panel comparison plot')
-        void pollJob(primary, PRIMARY_METHOD, true, false, 'succeeded')
+        void pollJob(primary, primaryMethod, true, false, 'succeeded')
       }
       return
     }
@@ -280,7 +399,7 @@ export default function OmniGridderDemoPage() {
         res = await fetch('/api/admin/omni-gridder/submit', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ methods }),
+          body: JSON.stringify({ methods, datasetId: selectedDatasetId }),
         })
       } catch {
         setGlobalError('Network error submitting job')
@@ -316,14 +435,14 @@ export default function OmniGridderDemoPage() {
       panelJobIdsRef.current = comparisonMode ? data.jobs.map((j) => j.jobId) : []
       succeededJobsRef.current = new Set()
       panelChainFiredRef.current = false
-      const hasPrimary = data.jobs.some((j) => j.method === PRIMARY_METHOD)
+      const hasPrimary = data.jobs.some((j) => j.method === primaryMethod)
       for (const { jobId, method } of data.jobs) {
         log(`Submitted ${jobId}`)
         updateRow(method, { jobId, status: 'queued', submittedAt })
         const chainPlot = comparisonMode
           ? false
           : hasPrimary
-            ? method === PRIMARY_METHOD
+            ? method === primaryMethod
             : method === data.jobs[0].method
         pollTimers.current.set(
           jobId,
@@ -338,7 +457,13 @@ export default function OmniGridderDemoPage() {
   )
 
   const runSingle = useCallback(() => runJobs([selectedMethod]), [runJobs, selectedMethod])
-  const runComparison = useCallback(() => runJobs(METHODS), [runJobs])
+  // Compare only what this dataset actually supports. Submitting a refused
+  // combination to prove it gets refused would burn a real job to demonstrate
+  // something the compatibility matrix already states.
+  const runComparison = useCallback(
+    () => runJobs(allowedMethods),
+    [runJobs, allowedMethods],
+  )
 
   const isRunning = activeMethods.some((m) => {
     const s = rows[m].status
@@ -349,22 +474,92 @@ export default function OmniGridderDemoPage() {
     <div className="min-h-screen bg-[#050505] text-white px-6 py-16">
       <div className="mx-auto max-w-5xl">
         <div className="mb-10">
-          <h1 className="text-3xl font-semibold tracking-tight mb-2">Omni-Gridder Method Comparison</h1>
+          <h1 className="text-3xl font-semibold tracking-tight mb-2">Omni-Gridder Showcase</h1>
           <p className="text-gray-400 font-light">
-            Submits real regrid jobs to og-server on Google Cloud (esmai-dev) against a live
-            0.25° GFS 500mb height field, regridded to a 0.5° CONUS grid, and compares
-            nearest-neighbor, bilinear, and conservative interpolation side by side.
+            Submits real regrid jobs to og-server on Google Cloud — no precomputed results.
+            Every dataset below runs through the same engine; which interpolation methods are
+            valid depends on the source geometry, and the engine refuses the combinations that
+            do not apply rather than returning an approximation.
           </p>
         </div>
+
+        {catalogError && (
+          <div className="mb-10 rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">
+            Could not load the dataset catalog: {catalogError}
+          </div>
+        )}
+
+        {/* Dataset picker. Each card states what that dataset demonstrates that
+            the others do not — the point of the catalog is variety of kind, not
+            a longer list of files. */}
+        <div className="mb-8 grid gap-3 sm:grid-cols-2">
+          {datasets.map((d) => {
+            const active = d.id === selectedDatasetId
+            return (
+              <button
+                key={d.id}
+                onClick={() => setSelectedDatasetId(d.id)}
+                disabled={isRunning}
+                className={`rounded-lg border p-4 text-left transition disabled:opacity-40 disabled:cursor-not-allowed ${
+                  active
+                    ? 'border-white/40 bg-white/10'
+                    : 'border-white/10 bg-[#0a0a0a] hover:border-white/25'
+                }`}
+              >
+                <div className="text-sm font-medium text-white">{d.label}</div>
+                <div className="mt-1 text-xs text-gray-400">{d.source}</div>
+                <div className="mt-2 text-xs text-gray-500">
+                  {d.nativeResolution} → {d.targetSummary}
+                  {d.destinationCells !== null && (
+                    <> · {d.destinationCells.toLocaleString()} cells</>
+                  )}
+                </div>
+                <div className="mt-2 text-xs text-gray-500 italic">{d.demonstrates}</div>
+              </button>
+            )
+          })}
+        </div>
+
+        {/* Compatibility matrix. Refused combinations carry the engine's own
+            reason — "why not" is the interesting part of this product, so it is
+            shown rather than hidden behind a disabled control with no
+            explanation. */}
+        {selectedDataset && (
+          <div className="mb-10 rounded-lg border border-white/10 bg-[#0a0a0a] p-4">
+            <div className="mb-3 text-xs uppercase tracking-wider text-gray-500">
+              Method compatibility · {selectedDataset.label}
+            </div>
+            <div className="space-y-2">
+              {selectedDataset.methods.map((m) => (
+                <div key={m.method} className="flex flex-wrap items-baseline gap-x-3 text-sm">
+                  <span className={m.allowed ? 'text-white' : 'text-gray-500 line-through'}>
+                    {METHOD_LABELS[m.method]}
+                  </span>
+                  {m.allowed ? (
+                    <span className="text-xs text-emerald-400">available</span>
+                  ) : (
+                    <span className="text-xs text-gray-500">{m.reason}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+            <div className="mt-3 text-xs text-gray-600">
+              Target CRS: {selectedDataset.targetCrsLabel}
+            </div>
+          </div>
+        )}
 
         <div className="mb-10 flex flex-wrap items-center gap-4">
           <select
             value={selectedMethod}
             onChange={(e) => setSelectedMethod(e.target.value as RegridMethod)}
-            disabled={isRunning}
+            disabled={isRunning || allowedMethods.length === 0}
             className="h-11 rounded-md border border-white/10 bg-[#0a0a0a] px-4 text-sm text-white disabled:opacity-40"
           >
-            {METHODS.map((m) => (
+            {/* Only valid methods are offered. A disabled option for a refused
+                combination would be a dead affordance — it reads as "one click
+                away" for something the server will reject. */}
+            {allowedMethods.map((m) => (
               <option key={m} value={m}>
                 {METHOD_LABELS[m]}
               </option>
@@ -391,6 +586,56 @@ export default function OmniGridderDemoPage() {
             {globalError}
           </div>
         )}
+
+        {/* Acceleration. Deliberately NOT a device toggle: the GPU apply path
+            exists and is parity-verified, but this demo does not exercise it,
+            and a control implying otherwise would be a dead affordance. The
+            live execution path arrives with the routing layer, where the
+            engine chooses the device and shows why. */}
+        <div className="mb-10 rounded-lg border border-white/10 bg-[#0a0a0a] p-5">
+          <div className="mb-3 flex items-center gap-2">
+            <span className="text-xs uppercase tracking-wider text-gray-500">Acceleration</span>
+            <ProvenanceBadge kind="verified" />
+          </div>
+          <p className="text-sm text-gray-300">
+            The engine separates weight <em>generation</em> (where accuracy lives) from weight{' '}
+            <em>application</em> (where speed lives). A GPU backend applies the same frozen
+            operator the CPU does, and is gated at ≤1e-12 relative error against the CPU result
+            — so a faster backend cannot change the science, by construction.
+          </p>
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="text-xs uppercase tracking-wider text-gray-500">
+                <tr>
+                  <th className="pb-2 pr-6 font-normal">Method</th>
+                  <th className="pb-2 pr-6 font-normal">Max relative error vs CPU</th>
+                  <th className="pb-2 font-normal">Result</th>
+                </tr>
+              </thead>
+              <tbody className="text-gray-300">
+                <tr>
+                  <td className="py-1 pr-6">Bilinear</td>
+                  <td className="py-1 pr-6 font-mono text-xs">1.2e-15</td>
+                  <td className="py-1 text-emerald-400">pass</td>
+                </tr>
+                <tr>
+                  <td className="py-1 pr-6">Nearest neighbour</td>
+                  <td className="py-1 pr-6 font-mono text-xs">0.0 (bitwise identical)</td>
+                  <td className="py-1 text-emerald-400">pass</td>
+                </tr>
+                <tr>
+                  <td className="py-1 pr-6">Conservative</td>
+                  <td className="py-1 pr-6 font-mono text-xs">1.0e-15</td>
+                  <td className="py-1 text-emerald-400">pass</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-3 text-xs italic text-gray-500">
+            Recorded verification on an NVIDIA L4, not a live run in this demo. The runs below
+            execute on CPU; the live GPU execution path ships with the routing layer.
+          </p>
+        </div>
 
         {workerTriggered === false && (
           <div className="mb-10 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4 text-sm text-yellow-200">
@@ -496,7 +741,7 @@ export default function OmniGridderDemoPage() {
           {plotUrl && (
             <div>
               <h2 className="font-mono text-[11px] uppercase tracking-wider text-gray-500 mb-3">
-                Result ({METHOD_LABELS[PRIMARY_METHOD]})
+                Result ({METHOD_LABELS[primaryMethod]})
               </h2>
               {/* Signed GCS URL from og-server — not a same-origin/known-host
                   asset, so next/image's optimizer can't be used without adding

--- a/src/app/api/admin/omni-gridder/datasets/route.ts
+++ b/src/app/api/admin/omni-gridder/datasets/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
+import { showcaseCatalogView } from '@/lib/showcase-catalog-view'
+
+/**
+ * The showcase dataset catalog, as the browser needs it.
+ *
+ * Serves the client-safe projection only — no `gs://` URIs. The client picks a
+ * dataset by id and the server resolves the id to a URI, so internal storage
+ * layout never reaches the page.
+ *
+ * Pure metadata computed in-process: no og-server call, no GCS read, no job
+ * submitted. It is therefore not rate-limited — there is nothing here to
+ * exhaust — but it is still admin-gated, because the catalog describes
+ * unreleased capability and this surface is not public yet.
+ */
+export async function GET(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
+  return NextResponse.json(
+    { datasets: showcaseCatalogView() },
+    // The catalog is a build-time constant in practice; let the browser reuse
+    // it across a session's navigations rather than refetching per page load.
+    { headers: { 'Cache-Control': 'private, max-age=300' } },
+  )
+}

--- a/src/lib/og-demo-inputs.ts
+++ b/src/lib/og-demo-inputs.ts
@@ -113,14 +113,21 @@ export const SWATH_METHOD_REFUSAL =
  * regrids to all-NaN, so these are taken from a run known to produce real
  * output.
  *
- * NOTE (pre-public, issue #89): these objects live in an `esmai-*` bucket — a
- * cross-project dependency that must move to an og-owned demo bucket before
- * this surface is opened publicly. Acceptable while the showcase is admin-only.
+ * They live in `gs://aetherisvision-og-demo`, an OG-owned bucket (uniform
+ * bucket-level access, public-access-prevention enforced, no lifecycle rule —
+ * these are demo INPUTS and must not expire; only job artifacts do). The
+ * og-server and og-worker runtime service accounts hold `objectViewer` and
+ * nothing more: the engine reads these and has no business writing to them.
+ *
+ * They were moved off the shared `esmai-*` bucket deliberately. That bucket's
+ * lifecycle is owned by another project, so an esmai-side cleanup could have
+ * removed the demo's inputs without warning — an availability risk, not just
+ * hygiene.
  */
 export const DEMO_DATASETS: DemoDataset[] = [
   {
     id: 'gfs-hgt500',
-    uri: 'gs://esmai-dev-esmai-objects/demo/hgt500_2026070706_f006.nc',
+    uri: 'gs://aetherisvision-og-demo/inputs/gfs/hgt500_2026070706_f006.nc',
     label: 'GFS 500 hPa geopotential height',
     source: 'NOAA GFS — global forecast model, +006 h',
     variable: 'hgt500',
@@ -136,7 +143,7 @@ export const DEMO_DATASETS: DemoDataset[] = [
   },
   {
     id: 'gfs-hgt500-utm',
-    uri: 'gs://esmai-dev-esmai-objects/demo/hgt500_2026070706_f006.nc',
+    uri: 'gs://aetherisvision-og-demo/inputs/gfs/hgt500_2026070706_f006.nc',
     label: 'GFS 500 hPa — onto a projected UTM grid',
     source: 'NOAA GFS — global forecast model, +006 h',
     variable: 'hgt500',
@@ -161,7 +168,7 @@ export const DEMO_DATASETS: DemoDataset[] = [
   },
   {
     id: 'goes18-abi-c13',
-    uri: 'gs://esmai-dev-esmai-objects/demo/multisat/bhiecbhied8920/goes18/granule.nc',
+    uri: 'gs://aetherisvision-og-demo/inputs/goes18/abi_c13_granule.nc',
     label: 'GOES-18 ABI band 13 — clean IR window',
     source: 'NOAA GOES-18 (GOES-West) ABI L1b',
     variable: 'C13',
@@ -182,7 +189,7 @@ export const DEMO_DATASETS: DemoDataset[] = [
   },
   {
     id: 'himawari9-ahi-c13',
-    uri: 'gs://esmai-dev-esmai-objects/demo/multisat/bhiecbhied8920/himawari9/granule.nc',
+    uri: 'gs://aetherisvision-og-demo/inputs/himawari9/ahi_c13_granule.nc',
     label: 'Himawari-9 AHI band 13 — clean IR window',
     source: 'JMA Himawari-9 AHI (ISatSS T001 tile)',
     variable: 'C13',

--- a/src/lib/og-demo-inputs.ts
+++ b/src/lib/og-demo-inputs.ts
@@ -24,14 +24,44 @@ import type { RegridMethod } from './omni-gridder-proxy'
  */
 export type DemoGeometry = 'rectilinear' | 'geostationary-swath'
 
-export interface DemoTargetGrid {
-  /** West, South, East, North in degrees. */
-  bbox: [number, number, number, number]
-  /** Uniform spacing in degrees, both axes. */
-  resolutionDeg: number
-  /** Human-readable region name, for the UI. */
-  region: string
-}
+/**
+ * A showcase destination grid.
+ *
+ * Modelled as a discriminated union rather than one shape with optional
+ * `crs`/`resolutionMeters` fields, so the invalid states are unrepresentable:
+ * with optional fields, "resolution is degrees unless crs is set, in which
+ * case it's metres" is an invariant living in a comment, and nothing stops a
+ * row from setting a projected CRS with a 0.03 spacing that silently means
+ * 3 cm. The tag forces the author to say which they meant.
+ *
+ * - `geographic` — lat/lon axes built here, in degrees.
+ * - `projected`  — built by og-server's `POST /v1/target-grids`, which owns
+ *   the PROJ math. Spacing is in the target CRS's native units (metres), and
+ *   `crs` may be the convenience key `"utm"` (auto-zone from the bbox
+ *   centroid; the response carries the resolved concrete EPSG code, never the
+ *   unresolved alias).
+ */
+export type DemoTargetGrid =
+  | {
+      kind: 'geographic'
+      /** West, South, East, North in degrees. */
+      bbox: [number, number, number, number]
+      /** Uniform spacing in degrees, both axes. */
+      resolutionDeg: number
+      /** Human-readable region name, for the UI. */
+      region: string
+    }
+  | {
+      kind: 'projected'
+      /** West, South, East, North in degrees (EPSG:4326), same as geographic. */
+      bbox: [number, number, number, number]
+      /** PROJ-acceptable CRS, or the convenience key `"utm"` / `"utm_auto"`. */
+      crs: string
+      /** Spacing in the target CRS's native units — metres for a projected CRS. */
+      resolutionMeters: number
+      /** Human-readable region name, for the UI. */
+      region: string
+    }
 
 export interface DemoDataset {
   id: string
@@ -97,12 +127,37 @@ export const DEMO_DATASETS: DemoDataset[] = [
     units: 'm',
     geometry: 'rectilinear',
     nativeResolution: '0.25° global',
-    target: { bbox: [-125, 24, -66, 49], resolutionDeg: 0.5, region: 'CONUS' },
+    target: { kind: 'geographic', bbox: [-125, 24, -66, 49], resolutionDeg: 0.5, region: 'CONUS' },
     // Rectilinear source: every method applies, which is what makes this the
     // dataset that can show a true three-way method comparison.
     allowedMethods: ['nearest', 'bilinear', 'conservative'],
     demonstrates:
       'Three-way method comparison on a smooth field, with conservation residual — the accuracy story.',
+  },
+  {
+    id: 'gfs-hgt500-utm',
+    uri: 'gs://esmai-dev-esmai-objects/demo/hgt500_2026070706_f006.nc',
+    label: 'GFS 500 hPa — onto a projected UTM grid',
+    source: 'NOAA GFS — global forecast model, +006 h',
+    variable: 'hgt500',
+    units: 'm',
+    geometry: 'rectilinear',
+    nativeResolution: '0.25° global',
+    // Same source field as `gfs-hgt500`, different DESTINATION CRS — which is
+    // the point: it isolates the projection axis from the method axis. The
+    // zone is resolved server-side from the bbox centroid, and the returned
+    // grid carries the concrete EPSG code rather than the "utm" alias, so the
+    // artifact records which zone was actually used.
+    target: {
+      kind: 'projected',
+      bbox: [-104, 33, -94, 40],
+      crs: 'utm',
+      resolutionMeters: 5000,
+      region: 'Southern Great Plains (UTM auto-zone)',
+    },
+    allowedMethods: ['nearest', 'bilinear', 'conservative'],
+    demonstrates:
+      'The same field onto a projected CRS — target-grid generation and zone selection happen in the engine, not the client.',
   },
   {
     id: 'goes18-abi-c13',
@@ -116,6 +171,7 @@ export const DEMO_DATASETS: DemoDataset[] = [
     // Proven values from the multi-satellite staging run: 0.03° over
     // -135..-100 E, 20..50 N is ~1.17M destination cells.
     target: {
+      kind: 'geographic',
       bbox: [-135, 20, -100, 50],
       resolutionDeg: 0.03,
       region: 'Western CONUS / eastern Pacific',
@@ -134,6 +190,7 @@ export const DEMO_DATASETS: DemoDataset[] = [
     geometry: 'geostationary-swath',
     nativeResolution: '2 km at nadir',
     target: {
+      kind: 'geographic',
       bbox: [70, 49, 106, 62],
       resolutionDeg: 0.02,
       region: 'Central Asia / southern Siberia',
@@ -160,9 +217,16 @@ export function datasetById(id: string | undefined): DemoDataset | null {
   return DEMO_DATASETS.find((d) => d.id === id) ?? null
 }
 
-/** Every URI the catalog can serve — the SSRF allowlist for compare_uri. */
+/**
+ * Every URI the catalog can serve — the SSRF allowlist for compare_uri.
+ *
+ * Deduplicated: two datasets may legitimately share a source URI when they
+ * differ only in destination (the same GFS field onto a geographic and a
+ * projected grid), and the allowlist is a set of permitted URIs, not a list of
+ * datasets.
+ */
 export function allowedInputUris(): string[] {
-  return DEMO_DATASETS.map((d) => d.uri)
+  return [...new Set(DEMO_DATASETS.map((d) => d.uri))]
 }
 
 /**
@@ -195,6 +259,17 @@ const MAX_DESTINATION_CELLS = 4_000_000
  * identical submissions must produce byte-identical numbers.
  */
 export function buildTargetGrid(dataset: DemoDataset): { lat: number[]; lon: number[] } {
+  if (dataset.target.kind !== 'geographic') {
+    // Projected grids are og-server's to build — it owns the PROJ math, and
+    // reimplementing zone selection or a projected axis walk here would be a
+    // second, quietly-diverging implementation of something the engine
+    // already does correctly. Callers must branch on `kind`; reaching here
+    // with a projected target is a caller bug, so it throws rather than
+    // falling back to a degrees interpretation of a metres spacing.
+    throw new Error(
+      `dataset ${dataset.id}: target is projected (${dataset.target.crs}) — build it via og-server POST /v1/target-grids, not locally`,
+    )
+  }
   const { bbox, resolutionDeg } = dataset.target
   const [west, south, east, north] = bbox
 

--- a/src/lib/og-demo-inputs.ts
+++ b/src/lib/og-demo-inputs.ts
@@ -1,19 +1,235 @@
-// Server-side allowlist of omni-gridder demo input URIs — shared by the
-// submit route (choosing the regrid input) and the status route (validating
-// the compare_uri passed back for the before/after plot panel). Never accept
-// an arbitrary client-supplied gs:// URI (SSRF / cross-tenant data exposure
-// via og-server reading whatever bucket/object we hand it). First entry is
-// the default. Configure via OG_DEMO_INPUT_URIS="gs://b/a.nc,gs://b/b.nc".
-export const DEFAULT_DEMO_INPUT_URIS = [
-  'gs://esmai-dev-esmai-objects/demo/hgt500_2026070706_f006.nc',
+import type { RegridMethod } from './omni-gridder-proxy'
+
+// Server-side catalog of omni-gridder showcase datasets — the single source of
+// truth for which inputs may be regridded, onto which target grid, by which
+// methods. Shared by the submit route (choosing the job spec) and the status
+// route (validating the compare_uri passed back for the before/after panel).
+//
+// Why a catalog and not a bare URI allowlist: the showcase has to demonstrate
+// COMPLEXITY, ACCURACY, SPEED and VARIETY, and those only show up when the
+// datasets differ in KIND — a rectilinear model field and two geostationary
+// satellite swaths from two different agencies exercise genuinely different
+// paths through the engine. A list of URIs cannot express the target grid each
+// one needs, nor which methods are valid for its geometry.
+//
+// Never accept an arbitrary client-supplied gs:// URI or dst_grid (SSRF /
+// cross-tenant data exposure via og-server reading whatever bucket we hand it;
+// resource exhaustion via a client asking for an enormous output array). The
+// client sends a dataset ID from this catalog and nothing else.
+
+/**
+ * How a dataset's source grid is geolocated. This decides which regridding
+ * methods are meaningful, so it is carried explicitly rather than inferred
+ * from the file at request time.
+ */
+export type DemoGeometry = 'rectilinear' | 'geostationary-swath'
+
+export interface DemoTargetGrid {
+  /** West, South, East, North in degrees. */
+  bbox: [number, number, number, number]
+  /** Uniform spacing in degrees, both axes. */
+  resolutionDeg: number
+  /** Human-readable region name, for the UI. */
+  region: string
+}
+
+export interface DemoDataset {
+  id: string
+  uri: string
+  label: string
+  /** Agency + instrument, shown as provenance in the UI. */
+  source: string
+  variable: string
+  units: string
+  geometry: DemoGeometry
+  /** Native resolution of the SOURCE, as a display string. */
+  nativeResolution: string
+  target: DemoTargetGrid
+  /**
+   * Methods valid for this dataset's source geometry. Enforced server-side —
+   * the UI disables the rest with a reason, but the proxy refuses them too,
+   * because a UI-only matrix is a suggestion, not a contract.
+   */
+  allowedMethods: RegridMethod[]
+  /** One line on what this dataset demonstrates that the others do not. */
+  demonstrates: string
+}
+
+/**
+ * Why the satellite rows refuse bilinear and conservative.
+ *
+ * A geostationary granule decodes to per-pixel `lat_2d`/`lon_2d` — swath
+ * geometry, not separable axes. `bilinear` requires a rectilinear SOURCE (it
+ * interpolates along two independent axes a swath does not have), and
+ * `conservative` is currently rectilinear-source-to-rectilinear-destination
+ * only. The engine refuses both with a specific error rather than silently
+ * returning an approximation, and the showcase surfaces that refusal
+ * deliberately: declining to answer when a method does not apply is a feature
+ * of this engine, not a gap in it.
+ */
+export const SWATH_METHOD_REFUSAL =
+  'Not applicable to swath geometry — a geostationary granule has per-pixel ' +
+  'geolocation, not separable lat/lon axes. The engine refuses this ' +
+  'combination rather than returning an approximation.'
+
+/**
+ * The showcase catalog.
+ *
+ * The two satellite granules are REAL staged granules from the multi-satellite
+ * demo (`scripts/multi-satellite-demo.sh` in the omni-gridder repo), which ran
+ * both satellites end-to-end against deployed staging through one
+ * catalog-driven code path. Their bboxes and resolutions are that run's proven
+ * values, not fresh guesses — a target grid that misses the granule footprint
+ * regrids to all-NaN, so these are taken from a run known to produce real
+ * output.
+ *
+ * NOTE (pre-public, issue #89): these objects live in an `esmai-*` bucket — a
+ * cross-project dependency that must move to an og-owned demo bucket before
+ * this surface is opened publicly. Acceptable while the showcase is admin-only.
+ */
+export const DEMO_DATASETS: DemoDataset[] = [
+  {
+    id: 'gfs-hgt500',
+    uri: 'gs://esmai-dev-esmai-objects/demo/hgt500_2026070706_f006.nc',
+    label: 'GFS 500 hPa geopotential height',
+    source: 'NOAA GFS — global forecast model, +006 h',
+    variable: 'hgt500',
+    units: 'm',
+    geometry: 'rectilinear',
+    nativeResolution: '0.25° global',
+    target: { bbox: [-125, 24, -66, 49], resolutionDeg: 0.5, region: 'CONUS' },
+    // Rectilinear source: every method applies, which is what makes this the
+    // dataset that can show a true three-way method comparison.
+    allowedMethods: ['nearest', 'bilinear', 'conservative'],
+    demonstrates:
+      'Three-way method comparison on a smooth field, with conservation residual — the accuracy story.',
+  },
+  {
+    id: 'goes18-abi-c13',
+    uri: 'gs://esmai-dev-esmai-objects/demo/multisat/bhiecbhied8920/goes18/granule.nc',
+    label: 'GOES-18 ABI band 13 — clean IR window',
+    source: 'NOAA GOES-18 (GOES-West) ABI L1b',
+    variable: 'C13',
+    units: 'K',
+    geometry: 'geostationary-swath',
+    nativeResolution: '2 km at nadir',
+    // Proven values from the multi-satellite staging run: 0.03° over
+    // -135..-100 E, 20..50 N is ~1.17M destination cells.
+    target: {
+      bbox: [-135, 20, -100, 50],
+      resolutionDeg: 0.03,
+      region: 'Western CONUS / eastern Pacific',
+    },
+    allowedMethods: ['ewa', 'nearest'],
+    demonstrates:
+      'Geostationary scan-angle geolocation through +proj=geos, EWA swath resampling onto a ~3 km grid — 1.17M destination cells.',
+  },
+  {
+    id: 'himawari9-ahi-c13',
+    uri: 'gs://esmai-dev-esmai-objects/demo/multisat/bhiecbhied8920/himawari9/granule.nc',
+    label: 'Himawari-9 AHI band 13 — clean IR window',
+    source: 'JMA Himawari-9 AHI (ISatSS T001 tile)',
+    variable: 'C13',
+    units: 'K',
+    geometry: 'geostationary-swath',
+    nativeResolution: '2 km at nadir',
+    target: {
+      bbox: [70, 49, 106, 62],
+      resolutionDeg: 0.02,
+      region: 'Central Asia / southern Siberia',
+    },
+    allowedMethods: ['ewa', 'nearest'],
+    demonstrates:
+      'A different agency and a different satellite through the IDENTICAL code path — onboarding a sensor is a catalog row, not a new adapter.',
+  },
 ]
 
+/** Default dataset when a request does not name one. */
+export const DEFAULT_DATASET_ID = DEMO_DATASETS[0].id
+
+/**
+ * Resolve a client-supplied dataset id against the catalog. Returns `null` for
+ * anything not in it — the caller turns that into a 400.
+ *
+ * An unknown id is never defaulted silently: a request naming a dataset we do
+ * not serve is a client error, and answering it with a different dataset's
+ * result would misreport what was computed.
+ */
+export function datasetById(id: string | undefined): DemoDataset | null {
+  if (!id) return DEMO_DATASETS.find((d) => d.id === DEFAULT_DATASET_ID) ?? null
+  return DEMO_DATASETS.find((d) => d.id === id) ?? null
+}
+
+/** Every URI the catalog can serve — the SSRF allowlist for compare_uri. */
 export function allowedInputUris(): string[] {
-  const raw = process.env.OG_DEMO_INPUT_URIS
-  if (!raw) return DEFAULT_DEMO_INPUT_URIS
-  const uris = raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-  return uris.length > 0 ? uris : DEFAULT_DEMO_INPUT_URIS
+  return DEMO_DATASETS.map((d) => d.uri)
+}
+
+/**
+ * Whether a method is valid for a dataset, and why not when it isn't.
+ * Server-side twin of the UI's compatibility matrix.
+ */
+export function methodRefusalReason(
+  dataset: DemoDataset,
+  method: RegridMethod,
+): string | null {
+  if (dataset.allowedMethods.includes(method)) return null
+  if (dataset.geometry === 'geostationary-swath') return SWATH_METHOD_REFUSAL
+  return `Method "${method}" is not enabled for dataset "${dataset.id}".`
+}
+
+/**
+ * Upper bound on destination cells for any showcase job. The catalog is
+ * trusted input, but a future edit that fat-fingers a resolution should fail
+ * loudly here rather than asking og-server to materialize a hundred-million-
+ * cell array. The largest catalogued grid today is ~1.17M cells.
+ */
+const MAX_DESTINATION_CELLS = 4_000_000
+
+/**
+ * Build a dataset's destination grid server-side.
+ *
+ * Axes run from the bbox minimum, inclusive of both endpoints where the
+ * spacing divides evenly, rounded to 6 decimals to keep the JSON compact and
+ * the values stable — a weight-cache key is derived from these axes, so
+ * identical submissions must produce byte-identical numbers.
+ */
+export function buildTargetGrid(dataset: DemoDataset): { lat: number[]; lon: number[] } {
+  const { bbox, resolutionDeg } = dataset.target
+  const [west, south, east, north] = bbox
+
+  if (!Number.isFinite(resolutionDeg) || resolutionDeg <= 0) {
+    throw new Error(
+      `dataset ${dataset.id}: resolution must be a finite positive number of degrees, got ${resolutionDeg}`,
+    )
+  }
+  if (!(east > west) || !(north > south)) {
+    throw new Error(
+      `dataset ${dataset.id}: bbox must satisfy west < east and south < north, got ${JSON.stringify(bbox)}`,
+    )
+  }
+
+  const axis = (start: number, end: number): number[] => {
+    // Floor, not round: an axis must never overshoot its bbox, and a spacing
+    // that does not divide the span evenly should stop short rather than
+    // extend past the granule footprint.
+    const steps = Math.floor((end - start) / resolutionDeg)
+    const out: number[] = []
+    for (let i = 0; i <= steps; i++) {
+      out.push(Math.round((start + i * resolutionDeg) * 1e6) / 1e6)
+    }
+    return out
+  }
+
+  const lat = axis(south, north)
+  const lon = axis(west, east)
+
+  const cells = lat.length * lon.length
+  if (cells > MAX_DESTINATION_CELLS) {
+    throw new Error(
+      `dataset ${dataset.id}: destination grid is ${cells} cells, above the ${MAX_DESTINATION_CELLS} showcase limit`,
+    )
+  }
+
+  return { lat, lon }
 }

--- a/src/lib/omni-gridder-client.ts
+++ b/src/lib/omni-gridder-client.ts
@@ -155,14 +155,18 @@ export interface JobDstGrid {
  */
 export function toJobDstGrid(grid: OmniGridderGrid): JobDstGrid {
   const axes = grid.coordinates
-  const lat = axes.y ?? axes.lat
-  const lon = axes.x ?? axes.lon
-  if (!lat || !lon) {
-    throw new Error(
-      `target grid "${grid.name}" has no embeddable axis pair — coordinates carry [${Object.keys(axes).join(', ')}], expected y/x or lat/lon`,
-    )
+  // A COHERENT pair only: y/x (projected) or lat/lon (geographic). A mixed
+  // pair like {y, lon} is contract drift, not a grid — embedding it would
+  // fail (or worse, half-work) in the worker instead of here.
+  if (axes.y && axes.x) {
+    return { name: grid.name, crs: grid.crs, lat: axes.y, lon: axes.x }
   }
-  return { name: grid.name, crs: grid.crs, lat, lon }
+  if (axes.lat && axes.lon) {
+    return { name: grid.name, crs: grid.crs, lat: axes.lat, lon: axes.lon }
+  }
+  throw new Error(
+    `target grid "${grid.name}" has no embeddable axis pair — coordinates carry [${Object.keys(axes).join(', ')}], expected y/x or lat/lon`,
+  )
 }
 
 /** Structural validation of a target-grid response. Throws with a specific reason. */
@@ -202,6 +206,18 @@ export function validateGrid(value: unknown): OmniGridderGrid {
       fail(`coordinate "${key}" has a non-finite value`)
     }
   }
+
+  // dim_names must name real axes whose lengths agree with shape —
+  // destinationCells is computed from shape, so an inconsistent response
+  // would misreport job size (or embed a grid the worker rejects) with no
+  // failure at this boundary.
+  g.dim_names.forEach((dim, i) => {
+    const axis = (g.coordinates as Record<string, unknown>)[dim]
+    if (!Array.isArray(axis)) fail(`dim_names[${i}] "${dim}" has no coordinate axis`)
+    if (axis.length !== (g.shape as number[])[i]) {
+      fail(`axis "${dim}" has ${axis.length} values but shape[${i}] is ${(g.shape as number[])[i]}`)
+    }
+  })
 
   return g as OmniGridderGrid
 }

--- a/src/lib/omni-gridder-client.ts
+++ b/src/lib/omni-gridder-client.ts
@@ -131,6 +131,40 @@ export async function generateTargetGrid(req: TargetGridRequest): Promise<OmniGr
   return validateGrid(await res.json())
 }
 
+/**
+ * The axis-array shape `JobSpec.params.dst_grid` requires: the worker's
+ * `parse_dst_grid` (og-process) reads the two separable axes from `lat`/`lon`
+ * regardless of interpretation — a projected grid puts its native-unit
+ * `y`/`x` axes under those same keys and carries `crs` to govern how they are
+ * read. See the C2 contract comment on `parse_dst_grid`.
+ */
+export interface JobDstGrid {
+  name: string
+  crs: string
+  lat: number[]
+  lon: number[]
+}
+
+/**
+ * Converts a `/v1/target-grids` response into the `dst_grid` shape a job spec
+ * embeds. The response names its coordinate axes per CRS family (`y`/`x` when
+ * projected, `lat`/`lon` when geographic); the worker's job contract uses
+ * `lat`/`lon` for both, so this is the one place the rename happens. Passing
+ * the response through verbatim instead fails in the worker with
+ * "dst_grid.lat array required" — after the job was accepted.
+ */
+export function toJobDstGrid(grid: OmniGridderGrid): JobDstGrid {
+  const axes = grid.coordinates
+  const lat = axes.y ?? axes.lat
+  const lon = axes.x ?? axes.lon
+  if (!lat || !lon) {
+    throw new Error(
+      `target grid "${grid.name}" has no embeddable axis pair — coordinates carry [${Object.keys(axes).join(', ')}], expected y/x or lat/lon`,
+    )
+  }
+  return { name: grid.name, crs: grid.crs, lat, lon }
+}
+
 /** Structural validation of a target-grid response. Throws with a specific reason. */
 export function validateGrid(value: unknown): OmniGridderGrid {
   // Annotated on the VARIABLE, not just the arrow: TypeScript only treats a

--- a/src/lib/omni-gridder-client.ts
+++ b/src/lib/omni-gridder-client.ts
@@ -21,6 +21,34 @@ export interface OmniGridderJobSpec {
   params: Record<string, unknown>
 }
 
+/**
+ * An `og_core::Grid` as returned by `POST /v1/target-grids`, ready to embed
+ * verbatim as a regrid job's `params.dst_grid`.
+ *
+ * Deliberately not re-modelled field-by-field: the grid is a pass-through
+ * artifact, and a partial local mirror of og-core's schema would be a second
+ * definition that drifts. Only the fields the showcase actually reads are
+ * named; the rest ride along untouched.
+ */
+export interface OmniGridderGrid {
+  name: string
+  shape: number[]
+  /** The RESOLVED CRS — never the `"utm"` alias, which og-server resolves to a concrete EPSG code before returning. */
+  crs: string
+  dim_names: string[]
+  coordinates: Record<string, number[]>
+}
+
+export interface TargetGridRequest {
+  name: string
+  /** PROJ-acceptable CRS, or the convenience key `"utm"` / `"utm_auto"`. */
+  crs: string
+  /** `[min_lon, min_lat, max_lon, max_lat]` in EPSG:4326 degrees. */
+  bbox: [number, number, number, number]
+  /** Spacing in the target CRS's native units — metres for a projected CRS. */
+  resolution: number
+}
+
 export interface OmniGridderJobDiagnostics {
   interpolation_method: string | null
   weight_cache_hit: boolean | null
@@ -63,6 +91,85 @@ async function ogFetch(path: string, init?: RequestInit): Promise<Response> {
       'X-Api-Key': OG_SERVER_API_KEY,
     },
   })
+}
+
+/**
+ * Ask og-server to generate a target grid.
+ *
+ * Grid generation lives in the engine, not here: og-geo is PROJ-backed and
+ * owns zone selection and the projected axis walk. A TypeScript
+ * reimplementation would be a second, quietly-diverging copy of coordinate
+ * math — and one whose errors would be invisible, because a plausible-looking
+ * grid regrids to plausible-looking garbage rather than failing.
+ *
+ * The response is validated, not trusted. It crosses a process boundary, so a
+ * 200 is not evidence the body has the shape the caller is about to embed;
+ * a malformed grid passed on as `dst_grid` would fail later, further away,
+ * with a worse message.
+ */
+export async function generateTargetGrid(req: TargetGridRequest): Promise<OmniGridderGrid> {
+  const res = await ogFetch('/v1/target-grids', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  })
+
+  if (!res.ok) {
+    // og-server returns { code, message } for this route; fall back to raw
+    // text when the body is not that shape (e.g. an infra-level error page).
+    const body = await res.text()
+    let detail = body
+    try {
+      const parsed = JSON.parse(body) as { code?: string; message?: string }
+      if (parsed.message) detail = `${parsed.code ?? 'ERROR'}: ${parsed.message}`
+    } catch {
+      // keep the raw text
+    }
+    throw new Error(`generateTargetGrid failed (${res.status}): ${detail}`)
+  }
+
+  return validateGrid(await res.json())
+}
+
+/** Structural validation of a target-grid response. Throws with a specific reason. */
+export function validateGrid(value: unknown): OmniGridderGrid {
+  // Annotated on the VARIABLE, not just the arrow: TypeScript only treats a
+  // call as control-flow-terminating when the binding itself is declared to
+  // return `never`. Without this the narrowing below silently stops working
+  // and every access reads as possibly-undefined — which invites papering
+  // over it with `!`, defeating the point of validating at all.
+  const fail: (why: string) => never = (why) => {
+    throw new Error(`generateTargetGrid returned a malformed grid: ${why}`)
+  }
+
+  if (typeof value !== 'object' || value === null) fail('not an object')
+  const g = value as Partial<OmniGridderGrid>
+
+  if (typeof g.name !== 'string') fail('missing name')
+  if (typeof g.crs !== 'string' || g.crs.length === 0) fail('missing crs')
+  // The alias must never survive into the returned grid: og-server resolves it
+  // to a concrete EPSG code so the artifact records the zone actually used. If
+  // it ever did survive, the provenance claim would be silently false.
+  if (/^utm(_auto)?$/i.test(g.crs.trim())) {
+    fail(`crs is the unresolved alias "${g.crs}" rather than a concrete CRS`)
+  }
+  if (!Array.isArray(g.shape) || g.shape.length === 0) fail('missing or empty shape')
+  if (!g.shape.every((n) => Number.isInteger(n) && n > 0)) {
+    fail('shape has a non-integer or non-positive entry')
+  }
+  if (!Array.isArray(g.dim_names) || g.dim_names.length !== g.shape.length) {
+    fail('dim_names does not match shape rank')
+  }
+  if (typeof g.coordinates !== 'object' || g.coordinates === null) fail('missing coordinates')
+
+  for (const [key, axis] of Object.entries(g.coordinates as Record<string, unknown>)) {
+    if (!Array.isArray(axis)) fail(`coordinate "${key}" is not an array`)
+    if (!(axis as unknown[]).every((n) => typeof n === 'number' && Number.isFinite(n))) {
+      fail(`coordinate "${key}" has a non-finite value`)
+    }
+  }
+
+  return g as OmniGridderGrid
 }
 
 export async function submitJob(spec: OmniGridderJobSpec): Promise<void> {

--- a/src/lib/omni-gridder-proxy.ts
+++ b/src/lib/omni-gridder-proxy.ts
@@ -166,6 +166,13 @@ export async function submitRegridBatch(
     }
   }
 
+  // A catalog row with no allowed methods is OUR misconfiguration — fail
+  // loudly before it becomes an `undefined` method in a job spec.
+  if (dataset.allowedMethods.length === 0) {
+    console.error(`omni-gridder submit: dataset "${dataset.id}" has no allowed methods`)
+    return { ok: false, status: 500, error: 'showcase dataset catalog is misconfigured' }
+  }
+
   const requestedMethods =
     body.methods && body.methods.length > 0 ? body.methods : [dataset.allowedMethods[0]]
   // Dedupe before validation/submission — {methods:["bilinear","bilinear"]}

--- a/src/lib/omni-gridder-proxy.ts
+++ b/src/lib/omni-gridder-proxy.ts
@@ -1,5 +1,11 @@
 import { NextResponse } from 'next/server'
-import { allowedInputUris } from './og-demo-inputs'
+import {
+  DEMO_DATASETS,
+  allowedInputUris,
+  buildTargetGrid,
+  datasetById,
+  methodRefusalReason,
+} from './og-demo-inputs'
 import {
   getJobStatus,
   submitJob,
@@ -45,13 +51,28 @@ export function proxyErrorResponse(err: ProxyError): NextResponse {
 
 // ---- Submit ----------------------------------------------------------------
 
-export type RegridMethod = 'nearest' | 'bilinear' | 'conservative'
-const VALID_METHODS: RegridMethod[] = ['nearest', 'bilinear', 'conservative']
+/**
+ * Methods the showcase can request. `ewa` (Elliptical Weighted Averaging) is
+ * the swath resampler — it is the method for satellite geolocation, and is
+ * meaningless on a rectilinear source, which is why validity is per-dataset
+ * (see `DemoDataset.allowedMethods`) and not a single global list.
+ */
+export type RegridMethod = 'nearest' | 'bilinear' | 'conservative' | 'ewa'
+const VALID_METHODS: RegridMethod[] = ['nearest', 'bilinear', 'conservative', 'ewa']
 
 export interface SubmitRequestBody {
-  /** One or more methods to run against the same input+grid. Defaults to ['bilinear']. */
+  /** One or more methods to run against the same dataset. Defaults to the dataset's first allowed method. */
   methods?: string[]
-  /** Must be one of the server allowlist; defaults to the first allowlisted URI. */
+  /**
+   * Dataset id from the showcase catalog. The client names a dataset; it never
+   * supplies a URI or a destination grid (SSRF / resource-exhaustion).
+   */
+  datasetId?: string
+  /**
+   * @deprecated Superseded by `datasetId`. Still accepted so an in-flight page
+   * load from before this change keeps working: it is resolved against the
+   * catalog by URI and rejected if it does not match a catalogued dataset.
+   */
   inputUri?: string
 }
 
@@ -63,6 +84,10 @@ export interface SubmittedJob {
 export interface SubmitResult {
   jobs: SubmittedJob[]
   inputUri: string
+  /** Which catalog dataset actually ran — the client should render what was computed, not what it asked for. */
+  datasetId: string
+  /** Destination cell count, so the UI can state the size of the job honestly rather than implying instant work. */
+  destinationCells: number
   workerTriggered: boolean
 }
 
@@ -81,17 +106,18 @@ export interface SubmitResult {
  */
 export type BudgetCheck = () => Promise<ProxyError | null>
 
-// 0.5° CONUS grid, generated server-side (never client-supplied — same SSRF/
-// resource-exhaustion reasoning as the input allowlist: an arbitrary dst_grid
-// from the client could ask og-server to materialize an enormous output
-// array). lat 24..49 step 0.5 = 51 points; lon -125..-66 step 0.5 = 119 points.
-function buildConusGrid(): { lat: number[]; lon: number[] } {
-  const lat: number[] = []
-  for (let i = 0; i <= 50; i++) lat.push(Math.round((24 + i * 0.5) * 1000) / 1000)
-  const lon: number[] = []
-  for (let i = 0; i <= 118; i++) lon.push(Math.round((-125 + i * 0.5) * 1000) / 1000)
-  return { lat, lon }
-}
+// The destination grid is generated server-side from the dataset catalog —
+// never client-supplied (same SSRF / resource-exhaustion reasoning as the
+// input allowlist: an arbitrary dst_grid could ask og-server to materialize an
+// enormous output array). See `buildTargetGrid` in ./og-demo-inputs.
+//
+// It replaced a hard-coded 0.5° CONUS grid, which it reproduces exactly for
+// the `gfs-hgt500` entry (lat 24..49 step 0.5 = 51 points; lon -125..-66 step
+// 0.5 = 119 points). That equivalence matters beyond tidiness: the weight
+// cache is keyed on the destination axes, so a grid that differed even in the
+// last decimal would silently orphan every cached operator built before this
+// change. Pinned by `buildTargetGrid reproduces the legacy CONUS grid` in
+// og-demo-inputs.test.ts.
 
 /**
  * Validate a submit request, optionally enforce a caller-supplied budget, then
@@ -109,8 +135,27 @@ export async function submitRegridBatch(
     return { ok: false, status: 500, error: 'OG_GCS_STAGING_BUCKET is not set' }
   }
 
+  // Resolve the dataset FIRST: it decides the destination grid and which
+  // methods are even meaningful, so method validation cannot be done against a
+  // global list ahead of it.
+  let dataset = datasetById(body.datasetId)
+  if (body.datasetId && !dataset) {
+    return { ok: false, status: 400, error: `Unknown dataset "${body.datasetId}"` }
+  }
+  if (!dataset && body.inputUri) {
+    // Deprecated URI form: resolve it against the catalog rather than trusting
+    // it. An allowlisted URI with no catalog row would have no target grid.
+    dataset = DEMO_DATASETS.find((d) => d.uri === body.inputUri) ?? null
+    if (!dataset) {
+      return { ok: false, status: 400, error: 'input URI is not in the server allowlist' }
+    }
+  }
+  if (!dataset) {
+    return { ok: false, status: 500, error: 'showcase dataset catalog is empty' }
+  }
+
   const requestedMethods =
-    body.methods && body.methods.length > 0 ? body.methods : ['bilinear']
+    body.methods && body.methods.length > 0 ? body.methods : [dataset.allowedMethods[0]]
   // Dedupe before validation/submission — {methods:["bilinear","bilinear"]}
   // would otherwise submit the same jobId twice and schedule duplicate polling
   // for what is really a single job. Preserve request order.
@@ -123,15 +168,25 @@ export async function submitRegridBatch(
       error: `Invalid method "${invalidMethod}" — must be one of ${VALID_METHODS.join(', ')}`,
     }
   }
-  if (methods.length > VALID_METHODS.length) {
+  // Per-dataset compatibility. The UI disables these combinations, but a
+  // UI-only matrix is a suggestion — refuse them here too, and return the
+  // ENGINE'S reason rather than a generic 400, because "why not" is the
+  // interesting part of this product.
+  for (const method of methods as RegridMethod[]) {
+    const refusal = methodRefusalReason(dataset, method)
+    if (refusal) {
+      return {
+        ok: false,
+        status: 400,
+        error: `"${method}" is not valid for ${dataset.label}. ${refusal}`,
+      }
+    }
+  }
+  if (methods.length > dataset.allowedMethods.length) {
     return { ok: false, status: 400, error: 'Too many methods requested' }
   }
 
-  const allowlist = allowedInputUris()
-  const inputUri = body.inputUri ?? allowlist[0]
-  if (!allowlist.includes(inputUri)) {
-    return { ok: false, status: 400, error: 'input URI is not in the server allowlist' }
-  }
+  const inputUri = dataset.uri
 
   // Budget / rate-class gate: after validation, before any external call — an
   // invalid request must never consume budget.
@@ -140,7 +195,20 @@ export async function submitRegridBatch(
     if (budgetError) return { ok: false, ...budgetError }
   }
 
-  const dstGrid = buildConusGrid()
+  // Built from the catalog, never from the client. A throw here means a
+  // malformed catalog entry (bad bbox/resolution, or a grid above the cell
+  // cap) — a SERVER bug, not a client one, so it must not be reported as a
+  // 400. Caught separately from the submission block below so the two failure
+  // modes stay distinguishable in logs.
+  let dstGrid: { lat: number[]; lon: number[] }
+  try {
+    dstGrid = buildTargetGrid(dataset)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`omni-gridder submit: invalid catalog entry — ${message}`)
+    return { ok: false, status: 500, error: 'showcase dataset catalog is misconfigured' }
+  }
+
   const batchSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
 
   try {
@@ -171,7 +239,13 @@ export async function submitRegridBatch(
 
     return {
       ok: true,
-      data: { jobs: submitted, inputUri, workerTriggered: workerTrigger.triggered },
+      data: {
+        jobs: submitted,
+        inputUri,
+        datasetId: dataset.id,
+        destinationCells: dstGrid.lat.length * dstGrid.lon.length,
+        workerTriggered: workerTrigger.triggered,
+      },
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)

--- a/src/lib/omni-gridder-proxy.ts
+++ b/src/lib/omni-gridder-proxy.ts
@@ -139,21 +139,31 @@ export async function submitRegridBatch(
 
   // Resolve the dataset FIRST: it decides the destination grid and which
   // methods are even meaningful, so method validation cannot be done against a
-  // global list ahead of it.
-  let dataset = datasetById(body.datasetId)
-  if (body.datasetId && !dataset) {
-    return { ok: false, status: 400, error: `Unknown dataset "${body.datasetId}"` }
-  }
-  if (!dataset && body.inputUri) {
+  // global list ahead of it. Resolution precedence matters: the deprecated
+  // inputUri form must be checked when datasetId is ABSENT — datasetById()
+  // falls back to the default dataset on undefined, which would otherwise
+  // make the URI-allowlist rejection below unreachable for exactly the
+  // callers it exists for (and silently run the default dataset for a
+  // request that named a different URI).
+  let dataset: ReturnType<typeof datasetById>
+  if (body.datasetId) {
+    dataset = datasetById(body.datasetId)
+    if (!dataset) {
+      return { ok: false, status: 400, error: `Unknown dataset "${body.datasetId}"` }
+    }
+  } else if (body.inputUri) {
     // Deprecated URI form: resolve it against the catalog rather than trusting
     // it. An allowlisted URI with no catalog row would have no target grid.
     dataset = DEMO_DATASETS.find((d) => d.uri === body.inputUri) ?? null
     if (!dataset) {
       return { ok: false, status: 400, error: 'input URI is not in the server allowlist' }
     }
-  }
-  if (!dataset) {
-    return { ok: false, status: 500, error: 'showcase dataset catalog is empty' }
+  } else {
+    // Bare body: neither identifier given — the documented default applies.
+    dataset = datasetById(undefined)
+    if (!dataset) {
+      return { ok: false, status: 500, error: 'showcase dataset catalog is empty' }
+    }
   }
 
   const requestedMethods =

--- a/src/lib/omni-gridder-proxy.ts
+++ b/src/lib/omni-gridder-proxy.ts
@@ -7,6 +7,7 @@ import {
   methodRefusalReason,
 } from './og-demo-inputs'
 import {
+  generateTargetGrid,
   getJobStatus,
   submitJob,
   triggerWorkerRun,
@@ -195,18 +196,55 @@ export async function submitRegridBatch(
     if (budgetError) return { ok: false, ...budgetError }
   }
 
-  // Built from the catalog, never from the client. A throw here means a
-  // malformed catalog entry (bad bbox/resolution, or a grid above the cell
-  // cap) — a SERVER bug, not a client one, so it must not be reported as a
-  // 400. Caught separately from the submission block below so the two failure
-  // modes stay distinguishable in logs.
-  let dstGrid: { lat: number[]; lon: number[] }
-  try {
-    dstGrid = buildTargetGrid(dataset)
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
-    console.error(`omni-gridder submit: invalid catalog entry — ${message}`)
-    return { ok: false, status: 500, error: 'showcase dataset catalog is misconfigured' }
+  // The destination grid comes from the catalog, never from the client — and
+  // for a PROJECTED target it comes from og-server, which owns the PROJ math.
+  //
+  // A throw in the geographic branch means a malformed catalog entry (bad
+  // bbox/resolution, or a grid above the cell cap) — a SERVER bug, not a
+  // client one, so it must not be reported as a 400. The projected branch can
+  // additionally fail on a network/auth problem reaching og-server, which is
+  // also not the caller's fault. Both are caught here, separately from the
+  // submission block below, so the failure modes stay distinguishable in logs.
+  let dstGrid: unknown
+  let destinationCells: number
+
+  if (dataset.target.kind === 'projected') {
+    // Note the units: `resolutionMeters`, because the target CRS is projected.
+    // The tagged union is what keeps this from silently being read as degrees.
+    try {
+      const grid = await generateTargetGrid({
+        name: `${dataset.id}-target`,
+        crs: dataset.target.crs,
+        bbox: dataset.target.bbox,
+        resolution: dataset.target.resolutionMeters,
+      })
+      dstGrid = grid
+      destinationCells = grid.shape.reduce((a, b) => a * b, 1)
+    } catch (err) {
+      // Upstream: og-server unreachable, unauthenticated, or returning a grid
+      // that failed validation. Reported as 502 — distinct from a catalog bug
+      // below — because "the engine did not answer" and "our catalog is wrong"
+      // want different responses from whoever is looking at the logs.
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`omni-gridder submit: target-grid generation failed for ${dataset.id} — ${message}`)
+      return {
+        ok: false,
+        status: 502,
+        error: 'the regridding engine could not generate the destination grid',
+      }
+    }
+  } else {
+    try {
+      const grid = buildTargetGrid(dataset)
+      dstGrid = grid
+      destinationCells = grid.lat.length * grid.lon.length
+    } catch (err) {
+      // A malformed catalog entry (bad bbox/resolution, or above the cell cap)
+      // is OUR bug, not the caller's, so it is never reported as a 400.
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`omni-gridder submit: invalid catalog entry — ${message}`)
+      return { ok: false, status: 500, error: 'showcase dataset catalog is misconfigured' }
+    }
   }
 
   const batchSuffix = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
@@ -243,7 +281,7 @@ export async function submitRegridBatch(
         jobs: submitted,
         inputUri,
         datasetId: dataset.id,
-        destinationCells: dstGrid.lat.length * dstGrid.lon.length,
+        destinationCells,
         workerTriggered: workerTrigger.triggered,
       },
     }

--- a/src/lib/omni-gridder-proxy.ts
+++ b/src/lib/omni-gridder-proxy.ts
@@ -10,6 +10,7 @@ import {
   generateTargetGrid,
   getJobStatus,
   submitJob,
+  toJobDstGrid,
   triggerWorkerRun,
   type OmniGridderJobStatus,
 } from './omni-gridder-client'
@@ -218,7 +219,10 @@ export async function submitRegridBatch(
         bbox: dataset.target.bbox,
         resolution: dataset.target.resolutionMeters,
       })
-      dstGrid = grid
+      // The response is NOT job-embeddable as-is: its projected axes live
+      // under coordinates.y/x, while the worker's dst_grid contract reads
+      // lat/lon. toJobDstGrid is the rename seam.
+      dstGrid = toJobDstGrid(grid)
       destinationCells = grid.shape.reduce((a, b) => a * b, 1)
     } catch (err) {
       // Upstream: og-server unreachable, unauthenticated, or returning a grid

--- a/src/lib/showcase-catalog-view.ts
+++ b/src/lib/showcase-catalog-view.ts
@@ -1,0 +1,126 @@
+import {
+  DEMO_DATASETS,
+  buildTargetGrid,
+  methodRefusalReason,
+  type DemoDataset,
+} from './og-demo-inputs'
+import type { RegridMethod } from './omni-gridder-proxy'
+
+// The client-safe projection of the showcase catalog.
+//
+// The browser needs to render the picker, the compatibility matrix, and the
+// honest job size — it does NOT need the `gs://` URIs. Those are the engine's
+// business, and shipping bucket paths to a page is how internal storage layout
+// leaks into screenshots and support threads. The client names a dataset by
+// id; the server resolves the id to a URI. This module is the seam that keeps
+// that true, and it is what a future PUBLIC showcase route will serve too.
+
+export const ALL_METHODS: RegridMethod[] = ['nearest', 'bilinear', 'conservative', 'ewa']
+
+export const METHOD_LABELS: Record<RegridMethod, string> = {
+  nearest: 'Nearest neighbour',
+  bilinear: 'Bilinear',
+  conservative: 'Conservative',
+  ewa: 'EWA (swath)',
+}
+
+/** Per-method availability for one dataset, carrying the reason when refused. */
+export interface MethodAvailability {
+  method: RegridMethod
+  allowed: boolean
+  /** Present only when `allowed` is false. The engine's reason, not a paraphrase. */
+  reason: string | null
+}
+
+export interface DatasetView {
+  id: string
+  label: string
+  source: string
+  variable: string
+  units: string
+  geometry: DemoDataset['geometry']
+  nativeResolution: string
+  demonstrates: string
+  /** Region name plus the resolution in its own units — never mixed. */
+  targetSummary: string
+  /** `EPSG:xxxx`-style label, or "geographic (EPSG:4326)". Projected zones resolve server-side. */
+  targetCrsLabel: string
+  /**
+   * Destination cell count. Exact for a geographic grid; for a projected one
+   * it is `null`, because the real number comes from og-server when the grid
+   * is generated and guessing it here would be a number the page could not
+   * stand behind.
+   */
+  destinationCells: number | null
+  methods: MethodAvailability[]
+  /** The method plotted when several run — the first allowed one, per dataset. */
+  primaryMethod: RegridMethod
+}
+
+/**
+ * The method whose result gets plotted when a comparison runs.
+ *
+ * Deliberately per-dataset rather than a module constant. The page previously
+ * hard-coded `bilinear`, which is not merely a style choice now: bilinear is
+ * INVALID on a swath source, so a fixed primary would have asked for a plot of
+ * a job that was refused and never submitted.
+ */
+export function primaryMethodFor(dataset: DemoDataset): RegridMethod {
+  return dataset.allowedMethods[0]
+}
+
+function targetSummary(dataset: DemoDataset): string {
+  const t = dataset.target
+  return t.kind === 'geographic'
+    ? `${t.region} · ${t.resolutionDeg}°`
+    : `${t.region} · ${t.resolutionMeters} m`
+}
+
+function targetCrsLabel(dataset: DemoDataset): string {
+  const t = dataset.target
+  if (t.kind === 'geographic') return 'geographic (EPSG:4326)'
+  // The alias is shown as "auto" rather than pretending to know the zone: the
+  // concrete EPSG code is resolved by og-server from the bbox centroid at
+  // submit time, and the result carries it. Displaying a guessed zone here
+  // would be a provenance claim the page has not earned.
+  return /^utm(_auto)?$/i.test(t.crs.trim()) ? 'UTM (zone resolved by the engine)' : t.crs
+}
+
+function destinationCells(dataset: DemoDataset): number | null {
+  if (dataset.target.kind !== 'geographic') return null
+  try {
+    const { lat, lon } = buildTargetGrid(dataset)
+    return lat.length * lon.length
+  } catch {
+    // A malformed catalog entry is reported by the submit path, which is where
+    // it can fail loudly. The picker should still render rather than blanking
+    // the whole page over one bad row.
+    return null
+  }
+}
+
+export function toDatasetView(dataset: DemoDataset): DatasetView {
+  return {
+    id: dataset.id,
+    label: dataset.label,
+    source: dataset.source,
+    variable: dataset.variable,
+    units: dataset.units,
+    geometry: dataset.geometry,
+    nativeResolution: dataset.nativeResolution,
+    demonstrates: dataset.demonstrates,
+    targetSummary: targetSummary(dataset),
+    targetCrsLabel: targetCrsLabel(dataset),
+    destinationCells: destinationCells(dataset),
+    methods: ALL_METHODS.map((method) => ({
+      method,
+      allowed: dataset.allowedMethods.includes(method),
+      reason: methodRefusalReason(dataset, method),
+    })),
+    primaryMethod: primaryMethodFor(dataset),
+  }
+}
+
+export function showcaseCatalogView(): DatasetView[] {
+  return DEMO_DATASETS.map(toDatasetView)
+}

--- a/src/lib/showcase-catalog-view.ts
+++ b/src/lib/showcase-catalog-view.ts
@@ -66,7 +66,13 @@ export interface DatasetView {
  * a job that was refused and never submitted.
  */
 export function primaryMethodFor(dataset: DemoDataset): RegridMethod {
-  return dataset.allowedMethods[0]
+  const primary = dataset.allowedMethods[0]
+  if (!primary) {
+    // A row with no methods would otherwise return `undefined` typed as
+    // RegridMethod and break the UI two lookups later (METHOD_LABELS etc.).
+    throw new Error(`showcase catalog row "${dataset.id}" has no allowed methods`)
+  }
+  return primary
 }
 
 function targetSummary(dataset: DemoDataset): string {

--- a/tests/integration/omni-gridder-api.test.ts
+++ b/tests/integration/omni-gridder-api.test.ts
@@ -21,7 +21,10 @@ vi.mock("@/lib/omni-gridder-client", () => ({
 
 const TEST_PASSPHRASE = "super-secret-test-passphrase";
 const TEST_BUCKET = "test-staging-bucket";
-const TEST_INPUT_URI = "gs://esmai-dev-esmai-objects/demo/hgt500_2026070706_f006.nc";
+// The gfs-hgt500 catalog row's URI (og-demo bucket) — the deprecated inputUri
+// form resolves against the CATALOG, so this must be a catalogued URI, not
+// the pre-migration staging-bucket path.
+const TEST_INPUT_URI = "gs://aetherisvision-og-demo/inputs/gfs/hgt500_2026070706_f006.nc";
 
 function hmacToken(passphrase: string): string {
   return createHmac("sha256", passphrase).update("admin-session").digest("hex");
@@ -223,8 +226,8 @@ describe("GET /api/admin/omni-gridder/status/[jobId] — chainPlot gating", () =
     getJobStatusMock.mockResolvedValue(baseStatus);
     const { GET } = await importStatusRoute();
 
-    // First entry of the default server-side allowlist (OG_DEMO_INPUT_URIS unset).
-    const allowed = "gs://esmai-dev-esmai-objects/demo/hgt500_2026070706_f006.nc";
+    // A catalogued input URI — the compare allowlist derives from the catalog.
+    const allowed = "gs://aetherisvision-og-demo/inputs/gfs/hgt500_2026070706_f006.nc";
     const req = new NextRequest(
       `http://localhost/api/admin/omni-gridder/status/${baseStatus.job_id}?chainPlot=1&compare=${encodeURIComponent(allowed)}`,
       { headers: adminHeaders("1.1.2.4") },

--- a/tests/unit/og-demo-inputs.test.ts
+++ b/tests/unit/og-demo-inputs.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEMO_DATASETS,
+  DEFAULT_DATASET_ID,
+  SWATH_METHOD_REFUSAL,
+  allowedInputUris,
+  buildTargetGrid,
+  datasetById,
+  methodRefusalReason,
+  type DemoDataset,
+} from "@/lib/og-demo-inputs";
+import type { RegridMethod } from "@/lib/omni-gridder-proxy";
+
+const gfs = () => datasetById("gfs-hgt500") as DemoDataset;
+const goes = () => datasetById("goes18-abi-c13") as DemoDataset;
+const himawari = () => datasetById("himawari9-ahi-c13") as DemoDataset;
+
+describe("showcase dataset catalog", () => {
+  it("serves a rectilinear model field and two geostationary satellites from different agencies", () => {
+    // The point of the catalog is VARIETY of KIND, not a longer list of files:
+    // one separable-axis source and two per-pixel-geolocated swaths exercise
+    // genuinely different paths through the engine. A catalog that drifted to
+    // three rectilinear files would still pass every other test here while
+    // demonstrating nothing.
+    expect(DEMO_DATASETS.filter((d) => d.geometry === "rectilinear").length).toBeGreaterThan(0);
+    expect(
+      DEMO_DATASETS.filter((d) => d.geometry === "geostationary-swath").length,
+    ).toBeGreaterThanOrEqual(2);
+
+    const agencies = new Set(DEMO_DATASETS.map((d) => d.source.split(" ")[0]));
+    expect(agencies.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("gives every dataset a distinct id and URI", () => {
+    const ids = DEMO_DATASETS.map((d) => d.id);
+    const uris = DEMO_DATASETS.map((d) => d.uri);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(uris).size).toBe(uris.length);
+  });
+
+  it("exposes exactly the catalogued URIs as the SSRF allowlist", () => {
+    expect(allowedInputUris().sort()).toEqual(DEMO_DATASETS.map((d) => d.uri).sort());
+  });
+
+  it("names a default dataset that exists", () => {
+    expect(datasetById(DEFAULT_DATASET_ID)).not.toBeNull();
+  });
+});
+
+describe("datasetById", () => {
+  it("returns the default for an absent id", () => {
+    expect(datasetById(undefined)?.id).toBe(DEFAULT_DATASET_ID);
+  });
+
+  it("returns null for an unknown id rather than silently defaulting", () => {
+    // Answering a request for a dataset we do not serve with a DIFFERENT
+    // dataset's result would misreport what was computed. This must stay a
+    // refusal, not a fallback.
+    expect(datasetById("no-such-dataset")).toBeNull();
+    expect(datasetById("")).not.toBeNull(); // empty string is "unspecified", not "unknown"
+  });
+});
+
+describe("method compatibility is per-geometry, not global", () => {
+  it("allows all three classical methods on the rectilinear source", () => {
+    for (const m of ["nearest", "bilinear", "conservative"] as RegridMethod[]) {
+      expect(methodRefusalReason(gfs(), m)).toBeNull();
+    }
+  });
+
+  it("refuses EWA on the rectilinear source", () => {
+    // EWA is the swath resampler; it is meaningless on separable axes.
+    expect(methodRefusalReason(gfs(), "ewa")).not.toBeNull();
+  });
+
+  it("refuses bilinear and conservative on both satellites, with the swath reason", () => {
+    for (const dataset of [goes(), himawari()]) {
+      for (const m of ["bilinear", "conservative"] as RegridMethod[]) {
+        const reason = methodRefusalReason(dataset, m);
+        expect(reason).toBe(SWATH_METHOD_REFUSAL);
+        // The reason is customer-facing copy: it must actually explain the
+        // geometry, not just say "unsupported".
+        expect(reason).toMatch(/per-pixel geolocation/);
+      }
+    }
+  });
+
+  it("allows EWA and nearest on both satellites", () => {
+    for (const dataset of [goes(), himawari()]) {
+      expect(methodRefusalReason(dataset, "ewa")).toBeNull();
+      expect(methodRefusalReason(dataset, "nearest")).toBeNull();
+    }
+  });
+
+  it("keeps allowedMethods and methodRefusalReason consistent for every dataset", () => {
+    // Two representations of the same fact — if they ever disagree, the UI
+    // (which reads allowedMethods) and the proxy (which calls
+    // methodRefusalReason) would enforce different matrices.
+    const every: RegridMethod[] = ["nearest", "bilinear", "conservative", "ewa"];
+    for (const dataset of DEMO_DATASETS) {
+      for (const m of every) {
+        const allowed = dataset.allowedMethods.includes(m);
+        expect(methodRefusalReason(dataset, m) === null).toBe(allowed);
+      }
+    }
+  });
+});
+
+describe("buildTargetGrid", () => {
+  it("reproduces the legacy CONUS grid exactly for the model field", () => {
+    // Regression pin, and the reason the generalization was safe to make: the
+    // weight cache is keyed on the destination axes, so a grid differing even
+    // in the last decimal would silently orphan every operator cached before
+    // the catalog replaced the hard-coded builder.
+    const { lat, lon } = buildTargetGrid(gfs());
+
+    expect(lat.length).toBe(51);
+    expect(lon.length).toBe(119);
+    expect(lat[0]).toBe(24);
+    expect(lat[lat.length - 1]).toBe(49);
+    expect(lon[0]).toBe(-125);
+    expect(lon[lon.length - 1]).toBe(-66);
+
+    // Value-for-value against the original implementation, not just endpoints.
+    const legacyLat = Array.from({ length: 51 }, (_, i) => Math.round((24 + i * 0.5) * 1000) / 1000);
+    const legacyLon = Array.from(
+      { length: 119 },
+      (_, i) => Math.round((-125 + i * 0.5) * 1000) / 1000,
+    );
+    expect(lat).toEqual(legacyLat);
+    expect(lon).toEqual(legacyLon);
+  });
+
+  it("builds the proven satellite grids at demo resolution", () => {
+    // These bboxes and resolutions came from a staging run known to produce
+    // real output; a grid that missed the granule footprint would regrid to
+    // all-NaN and still "succeed".
+    const g = buildTargetGrid(goes());
+    expect(g.lat.length * g.lon.length).toBeGreaterThan(1_000_000);
+    expect(g.lat[0]).toBe(20);
+    expect(g.lon[0]).toBe(-135);
+
+    const h = buildTargetGrid(himawari());
+    expect(h.lat.length * h.lon.length).toBeGreaterThan(1_000_000);
+    expect(h.lat[0]).toBe(49);
+    expect(h.lon[0]).toBe(70);
+  });
+
+  it("never overshoots the bbox", () => {
+    for (const dataset of DEMO_DATASETS) {
+      const [west, south, east, north] = dataset.target.bbox;
+      const { lat, lon } = buildTargetGrid(dataset);
+      expect(lat[0]).toBeGreaterThanOrEqual(south);
+      expect(lat[lat.length - 1]).toBeLessThanOrEqual(north);
+      expect(lon[0]).toBeGreaterThanOrEqual(west);
+      expect(lon[lon.length - 1]).toBeLessThanOrEqual(east);
+    }
+  });
+
+  it("produces strictly increasing axes at the catalogued spacing", () => {
+    for (const dataset of DEMO_DATASETS) {
+      const { lat, lon } = buildTargetGrid(dataset);
+      for (const axis of [lat, lon]) {
+        expect(axis.length).toBeGreaterThan(1);
+        for (let i = 1; i < axis.length; i++) {
+          expect(axis[i]).toBeGreaterThan(axis[i - 1]);
+        }
+      }
+      // Spacing holds to the rounding precision the builder applies.
+      expect(lat[1] - lat[0]).toBeCloseTo(dataset.target.resolutionDeg, 6);
+    }
+  });
+
+  it("keeps every catalogued grid under the showcase cell cap", () => {
+    for (const dataset of DEMO_DATASETS) {
+      const { lat, lon } = buildTargetGrid(dataset);
+      expect(lat.length * lon.length).toBeLessThanOrEqual(4_000_000);
+    }
+  });
+});
+
+describe("buildTargetGrid error paths", () => {
+  // A malformed catalog entry is a server bug. It must fail loudly at build
+  // time rather than asking og-server to materialize a degenerate or enormous
+  // array — so these paths get their own tests, not just the happy path.
+  const withTarget = (target: Partial<DemoDataset["target"]>): DemoDataset => ({
+    ...gfs(),
+    target: { ...gfs().target, ...target },
+  });
+
+  it("rejects a non-positive or non-finite resolution", () => {
+    for (const bad of [0, -0.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => buildTargetGrid(withTarget({ resolutionDeg: bad }))).toThrow(/resolution/);
+    }
+  });
+
+  it("rejects an inverted or degenerate bbox", () => {
+    expect(() => buildTargetGrid(withTarget({ bbox: [10, 0, -10, 20] }))).toThrow(/bbox/);
+    expect(() => buildTargetGrid(withTarget({ bbox: [0, 20, 10, 0] }))).toThrow(/bbox/);
+    expect(() => buildTargetGrid(withTarget({ bbox: [5, 0, 5, 20] }))).toThrow(/bbox/);
+  });
+
+  it("rejects a grid above the cell cap instead of building it", () => {
+    expect(() =>
+      buildTargetGrid(withTarget({ bbox: [-180, -90, 180, 90], resolutionDeg: 0.01 })),
+    ).toThrow(/showcase limit/);
+  });
+});

--- a/tests/unit/og-demo-inputs.test.ts
+++ b/tests/unit/og-demo-inputs.test.ts
@@ -12,8 +12,13 @@ import {
 import type { RegridMethod } from "@/lib/omni-gridder-proxy";
 
 const gfs = () => datasetById("gfs-hgt500") as DemoDataset;
+const gfsUtm = () => datasetById("gfs-hgt500-utm") as DemoDataset;
 const goes = () => datasetById("goes18-abi-c13") as DemoDataset;
 const himawari = () => datasetById("himawari9-ahi-c13") as DemoDataset;
+
+/** Datasets whose grid this module builds; projected ones are og-server's. */
+const geographicDatasets = () =>
+  DEMO_DATASETS.filter((d) => d.target.kind === "geographic");
 
 describe("showcase dataset catalog", () => {
   it("serves a rectilinear model field and two geostationary satellites from different agencies", () => {
@@ -31,15 +36,25 @@ describe("showcase dataset catalog", () => {
     expect(agencies.size).toBeGreaterThanOrEqual(2);
   });
 
-  it("gives every dataset a distinct id and URI", () => {
+  it("gives every dataset a distinct id", () => {
     const ids = DEMO_DATASETS.map((d) => d.id);
-    const uris = DEMO_DATASETS.map((d) => d.uri);
     expect(new Set(ids).size).toBe(ids.length);
-    expect(new Set(uris).size).toBe(uris.length);
   });
 
-  it("exposes exactly the catalogued URIs as the SSRF allowlist", () => {
-    expect(allowedInputUris().sort()).toEqual(DEMO_DATASETS.map((d) => d.uri).sort());
+  it("allows two datasets to share a source URI when they differ in destination", () => {
+    // Deliberate: `gfs-hgt500` and `gfs-hgt500-utm` are the SAME field onto
+    // different target CRSs. The dataset id — not the URI — is the identity
+    // here, because what distinguishes them is where the data is going, not
+    // where it came from.
+    const shared = DEMO_DATASETS.filter((d) => d.uri === gfs().uri);
+    expect(shared.length).toBeGreaterThan(1);
+    expect(new Set(shared.map((d) => d.id)).size).toBe(shared.length);
+  });
+
+  it("exposes the catalogued URIs as a deduplicated SSRF allowlist", () => {
+    const allowlist = allowedInputUris();
+    expect(new Set(allowlist).size).toBe(allowlist.length);
+    expect(new Set(allowlist)).toEqual(new Set(DEMO_DATASETS.map((d) => d.uri)));
   });
 
   it("names a default dataset that exists", () => {
@@ -147,7 +162,7 @@ describe("buildTargetGrid", () => {
   });
 
   it("never overshoots the bbox", () => {
-    for (const dataset of DEMO_DATASETS) {
+    for (const dataset of geographicDatasets()) {
       const [west, south, east, north] = dataset.target.bbox;
       const { lat, lon } = buildTargetGrid(dataset);
       expect(lat[0]).toBeGreaterThanOrEqual(south);
@@ -158,7 +173,8 @@ describe("buildTargetGrid", () => {
   });
 
   it("produces strictly increasing axes at the catalogued spacing", () => {
-    for (const dataset of DEMO_DATASETS) {
+    for (const dataset of geographicDatasets()) {
+      if (dataset.target.kind !== "geographic") continue; // narrowing for TS
       const { lat, lon } = buildTargetGrid(dataset);
       for (const axis of [lat, lon]) {
         expect(axis.length).toBeGreaterThan(1);
@@ -172,10 +188,38 @@ describe("buildTargetGrid", () => {
   });
 
   it("keeps every catalogued grid under the showcase cell cap", () => {
-    for (const dataset of DEMO_DATASETS) {
+    for (const dataset of geographicDatasets()) {
       const { lat, lon } = buildTargetGrid(dataset);
       expect(lat.length * lon.length).toBeLessThanOrEqual(4_000_000);
     }
+  });
+
+  it("refuses to build a projected grid locally", () => {
+    // og-server owns the PROJ math. Building it here would be a second,
+    // quietly-diverging implementation — and a metres spacing read as degrees
+    // is a bug that does not announce itself, so this must throw rather than
+    // fall back.
+    expect(() => buildTargetGrid(gfsUtm())).toThrow(/POST \/v1\/target-grids/);
+  });
+});
+
+describe("the projected row isolates the CRS axis", () => {
+  it("uses the same source field as the geographic row, differing only in destination", () => {
+    // A comparison that changed the field AND the CRS at once would confound
+    // two variables; the showcase claim is "same data, same method, different
+    // target CRS".
+    expect(gfsUtm().uri).toBe(gfs().uri);
+    expect(gfsUtm().variable).toBe(gfs().variable);
+    expect(gfsUtm().allowedMethods).toEqual(gfs().allowedMethods);
+    expect(gfsUtm().target.kind).toBe("projected");
+    expect(gfs().target.kind).toBe("geographic");
+  });
+
+  it("specifies its spacing in metres, not degrees", () => {
+    const target = gfsUtm().target;
+    if (target.kind !== "projected") throw new Error("expected a projected target");
+    expect(target.resolutionMeters).toBeGreaterThan(100);
+    expect(target.crs).toMatch(/^utm/);
   });
 });
 
@@ -183,9 +227,15 @@ describe("buildTargetGrid error paths", () => {
   // A malformed catalog entry is a server bug. It must fail loudly at build
   // time rather than asking og-server to materialize a degenerate or enormous
   // array — so these paths get their own tests, not just the happy path.
-  const withTarget = (target: Partial<DemoDataset["target"]>): DemoDataset => ({
+  type GeographicTarget = Extract<DemoDataset["target"], { kind: "geographic" }>;
+  const baseTarget = (): GeographicTarget => {
+    const t = gfs().target;
+    if (t.kind !== "geographic") throw new Error("gfs-hgt500 must have a geographic target");
+    return t;
+  };
+  const withTarget = (patch: Partial<Omit<GeographicTarget, "kind">>): DemoDataset => ({
     ...gfs(),
-    target: { ...gfs().target, ...target },
+    target: { ...baseTarget(), ...patch },
   });
 
   it("rejects a non-positive or non-finite resolution", () => {

--- a/tests/unit/omni-gridder-grid-validation.test.ts
+++ b/tests/unit/omni-gridder-grid-validation.test.ts
@@ -14,9 +14,11 @@ import {
 // the error paths, not just the happy one: a validator whose rejections are
 // untested is a validator nobody knows still rejects.
 
+// Internally consistent: shape must agree with the axis lengths, because
+// validateGrid enforces it (destinationCells is computed from shape).
 const validGrid = (): OmniGridderGrid => ({
   name: "gfs-hgt500-utm-target",
-  shape: [140, 200],
+  shape: [3, 3],
   crs: "EPSG:32614",
   dim_names: ["y", "x"],
   coordinates: {
@@ -54,6 +56,7 @@ describe("toJobDstGrid produces the worker's dst_grid contract", () => {
     const g: OmniGridderGrid = {
       ...validGrid(),
       crs: "EPSG:4326",
+      shape: [2, 2],
       dim_names: ["lat", "lon"],
       coordinates: { lat: [33, 34], lon: [-104, -103] },
     };
@@ -65,6 +68,16 @@ describe("toJobDstGrid produces the worker's dst_grid contract", () => {
     });
   });
 
+  it("rejects a mixed axis pair rather than embedding it", () => {
+    // {y, lon} is contract drift between the two families, not a grid —
+    // it must fail here, not half-work in the worker.
+    const g: OmniGridderGrid = {
+      ...validGrid(),
+      coordinates: { y: [1, 2, 3], lon: [-104, -103, -102] },
+    };
+    expect(() => toJobDstGrid(g)).toThrow(/no embeddable axis pair.*y, lon/);
+  });
+
   it("throws a specific error when no embeddable axis pair exists", () => {
     // A response with axis names this seam does not model must fail HERE,
     // not in the worker after the job was already accepted.
@@ -73,6 +86,18 @@ describe("toJobDstGrid produces the worker's dst_grid contract", () => {
       coordinates: { pix: [1, 2, 3] },
     };
     expect(() => toJobDstGrid(g)).toThrow(/no embeddable axis pair.*pix/);
+  });
+});
+
+describe("validateGrid enforces shape/axis consistency", () => {
+  it("rejects an axis whose length disagrees with shape", () => {
+    const g = { ...validGrid(), shape: [140, 200] };
+    expect(() => validateGrid(g)).toThrow(/axis "y" has 3 values but shape\[0\] is 140/);
+  });
+
+  it("rejects dim_names naming an axis that coordinates does not carry", () => {
+    const g = { ...validGrid(), dim_names: ["y", "time"] };
+    expect(() => validateGrid(g)).toThrow(/"time" has no coordinate axis/);
   });
 });
 

--- a/tests/unit/omni-gridder-grid-validation.test.ts
+++ b/tests/unit/omni-gridder-grid-validation.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { validateGrid, type OmniGridderGrid } from "@/lib/omni-gridder-client";
+import {
+  toJobDstGrid,
+  validateGrid,
+  type OmniGridderGrid,
+} from "@/lib/omni-gridder-client";
 
-// `POST /v1/target-grids` returns a grid that is embedded verbatim as a regrid
-// job's `dst_grid`. It crosses a process boundary, so a 200 is not evidence the
+// `POST /v1/target-grids` returns a grid that is validated, then converted by
+// `toJobDstGrid` into the `dst_grid` shape a job spec embeds (the response's
+// projected axes live under coordinates.y/x; the worker reads lat/lon). It
+// crosses a process boundary, so a 200 is not evidence the
 // body has the shape we are about to pass on — and a malformed grid handed to
 // og-server fails later, further away, with a worse message. These tests cover
 // the error paths, not just the happy one: a validator whose rejections are
@@ -30,6 +36,43 @@ describe("validateGrid accepts a well-formed grid", () => {
     // along rather than be stripped or rejected.
     const g = { ...validGrid(), some_future_field: { nested: true } };
     expect(validateGrid(g)).toMatchObject({ crs: "EPSG:32614" });
+  });
+});
+
+describe("toJobDstGrid produces the worker's dst_grid contract", () => {
+  it("renames projected y/x axes to lat/lon and carries crs", () => {
+    const g = validGrid();
+    expect(toJobDstGrid(g)).toEqual({
+      name: "gfs-hgt500-utm-target",
+      crs: "EPSG:32614",
+      lat: g.coordinates.y,
+      lon: g.coordinates.x,
+    });
+  });
+
+  it("passes geographic lat/lon axes through under the same keys", () => {
+    const g: OmniGridderGrid = {
+      ...validGrid(),
+      crs: "EPSG:4326",
+      dim_names: ["lat", "lon"],
+      coordinates: { lat: [33, 34], lon: [-104, -103] },
+    };
+    expect(toJobDstGrid(g)).toEqual({
+      name: g.name,
+      crs: "EPSG:4326",
+      lat: [33, 34],
+      lon: [-104, -103],
+    });
+  });
+
+  it("throws a specific error when no embeddable axis pair exists", () => {
+    // A response with axis names this seam does not model must fail HERE,
+    // not in the worker after the job was already accepted.
+    const g: OmniGridderGrid = {
+      ...validGrid(),
+      coordinates: { pix: [1, 2, 3] },
+    };
+    expect(() => toJobDstGrid(g)).toThrow(/no embeddable axis pair.*pix/);
   });
 });
 

--- a/tests/unit/omni-gridder-grid-validation.test.ts
+++ b/tests/unit/omni-gridder-grid-validation.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { validateGrid, type OmniGridderGrid } from "@/lib/omni-gridder-client";
+
+// `POST /v1/target-grids` returns a grid that is embedded verbatim as a regrid
+// job's `dst_grid`. It crosses a process boundary, so a 200 is not evidence the
+// body has the shape we are about to pass on — and a malformed grid handed to
+// og-server fails later, further away, with a worse message. These tests cover
+// the error paths, not just the happy one: a validator whose rejections are
+// untested is a validator nobody knows still rejects.
+
+const validGrid = (): OmniGridderGrid => ({
+  name: "gfs-hgt500-utm-target",
+  shape: [140, 200],
+  crs: "EPSG:32614",
+  dim_names: ["y", "x"],
+  coordinates: {
+    y: [3_650_000, 3_655_000, 3_660_000],
+    x: [400_000, 405_000, 410_000],
+  },
+});
+
+describe("validateGrid accepts a well-formed grid", () => {
+  it("returns the grid unchanged", () => {
+    const g = validGrid();
+    expect(validateGrid(g)).toEqual(g);
+  });
+
+  it("passes a grid whose extra fields it does not model", () => {
+    // The grid is a pass-through artifact; unknown og-core fields must ride
+    // along rather than be stripped or rejected.
+    const g = { ...validGrid(), some_future_field: { nested: true } };
+    expect(validateGrid(g)).toMatchObject({ crs: "EPSG:32614" });
+  });
+});
+
+describe("validateGrid rejects structural damage", () => {
+  it("rejects non-objects", () => {
+    for (const bad of [null, undefined, 42, "grid", []]) {
+      // An array passes `typeof === "object"`, so it must be caught by the
+      // field checks rather than assumed away.
+      expect(() => validateGrid(bad)).toThrow(/malformed grid/);
+    }
+  });
+
+  it("rejects a missing or empty crs", () => {
+    expect(() => validateGrid({ ...validGrid(), crs: undefined })).toThrow(/crs/);
+    expect(() => validateGrid({ ...validGrid(), crs: "" })).toThrow(/crs/);
+    expect(() => validateGrid({ ...validGrid(), crs: 32614 })).toThrow(/crs/);
+  });
+
+  it("rejects a shape that is missing, empty, or not positive integers", () => {
+    expect(() => validateGrid({ ...validGrid(), shape: undefined })).toThrow(/shape/);
+    expect(() => validateGrid({ ...validGrid(), shape: [] })).toThrow(/shape/);
+    expect(() => validateGrid({ ...validGrid(), shape: [140, 0] })).toThrow(/shape/);
+    expect(() => validateGrid({ ...validGrid(), shape: [140, -1] })).toThrow(/shape/);
+    expect(() => validateGrid({ ...validGrid(), shape: [140, 1.5] })).toThrow(/shape/);
+  });
+
+  it("rejects dim_names that disagree with the shape rank", () => {
+    expect(() => validateGrid({ ...validGrid(), dim_names: ["y"] })).toThrow(/dim_names/);
+    expect(() => validateGrid({ ...validGrid(), dim_names: undefined })).toThrow(/dim_names/);
+  });
+
+  it("rejects missing or non-finite coordinates", () => {
+    expect(() => validateGrid({ ...validGrid(), coordinates: undefined })).toThrow(/coordinates/);
+    expect(() =>
+      validateGrid({ ...validGrid(), coordinates: { y: [1, Number.NaN], x: [1] } }),
+    ).toThrow(/non-finite/);
+    expect(() =>
+      validateGrid({ ...validGrid(), coordinates: { y: [1, Number.POSITIVE_INFINITY], x: [1] } }),
+    ).toThrow(/non-finite/);
+    expect(() => validateGrid({ ...validGrid(), coordinates: { y: "1,2,3" } })).toThrow(
+      /not an array/,
+    );
+  });
+
+  it("rejects a missing name", () => {
+    expect(() => validateGrid({ ...validGrid(), name: undefined })).toThrow(/name/);
+  });
+});
+
+describe("validateGrid rejects an unresolved UTM alias", () => {
+  // og-server resolves "utm" to a concrete EPSG zone BEFORE returning, so the
+  // artifact records which zone was actually used. If the alias ever survived
+  // into a stored grid, the provenance claim would be silently false — the
+  // artifact would say "utm" forever and no one could tell which zone ran.
+  it("refuses the literal alias in any casing or padding", () => {
+    for (const alias of ["utm", "UTM", "Utm", " utm ", "utm_auto", "UTM_AUTO"]) {
+      expect(() => validateGrid({ ...validGrid(), crs: alias })).toThrow(/unresolved alias/);
+    }
+  });
+
+  it("accepts a resolved zone in either hemisphere", () => {
+    expect(validateGrid({ ...validGrid(), crs: "EPSG:32614" }).crs).toBe("EPSG:32614");
+    expect(validateGrid({ ...validGrid(), crs: "EPSG:32714" }).crs).toBe("EPSG:32714");
+  });
+
+  it("does not reject a legitimate CRS that merely contains the letters", () => {
+    // The check is anchored, not a substring match — a PROJ string mentioning
+    // the projection by name is a real, resolved CRS.
+    const projString = "+proj=utm +zone=14 +datum=WGS84 +units=m +no_defs";
+    expect(validateGrid({ ...validGrid(), crs: projString }).crs).toBe(projString);
+  });
+});


### PR DESCRIPTION
## Summary

The #89 showcase lane, e2e-proven against staging (4/4 datasets PASS through the deployed preview — see issue #89 for the run record and job ids).

- **Dataset catalog** (`og-demo-inputs.ts`): single-URI allowlist → structured catalog of 4 rows (GFS geographic, GFS→UTM projected, GOES-18 ABI C13, Himawari-9 AHI C13), each with target grid, source geometry, allowed methods, and what it demonstrates. `DemoTargetGrid` is a discriminated union (`geographic | projected`) so projected resolution is meters by type, not comment.
- **UI**: dataset picker, method×geometry compatibility matrix surfacing the engine's verbatim refusal text, ProvenanceBadge on every number (live run vs recorded verification), L4 parity panel as recorded verification, weight-reuse panel measuring the cold/warm pair in-session (classified by `weight_cache_hit`, not run order).
- **Proxy hardening**: `generateTargetGrid` + `validateGrid` (rejects the unresolved `utm` alias), distinct 502/500 error codes, client-safe catalog view (no `gs://` URIs reach the browser), per-IP submit budget.
- **Contract fix found by the live e2e**: `/v1/target-grids` returns projected axes as `coordinates.y/x`; the worker reads `lat`/`lon`+`crs`. `toJobDstGrid()` is the one rename seam, throwing specifically when no embeddable axis pair exists.

Site stays passphrase-locked — merging this does not open anything.

## Test plan
- [x] 48 unit tests green, typecheck clean
- [x] Live e2e on the deployed preview: all 4 datasets submit → og-server → staging worker → signed result (issue #89, comment 5074379745)

🤖 Generated with [Claude Code](https://claude.com/claude-code)