### PR TITLE
ci: mirror every website ref to GitLab

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -4,6 +4,7 @@ name: Mirror to GitLab
 # recovery repository to GitHub's complete branch-and-tag state.
 on:
   push:
+  create:
   delete:
   schedule:
     - cron: '17 5 * * *'
@@ -29,11 +30,14 @@ jobs:
       - name: Check out the canonical branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: main
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
 
       - name: Fetch the complete GitHub ref set
         run: |
+          set -euo pipefail
+          git for-each-ref --format='delete %(refname)' refs/mirror/heads |
+            git update-ref --stdin
           git fetch --force --prune --prune-tags origin \
             '+refs/heads/*:refs/mirror/heads/*' \
             '+refs/tags/*:refs/tags/*'

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,25 +1,55 @@
-name: Mirror → GitLab
+name: Mirror to GitLab
 
-# Runs whenever main is updated (direct push or PR merge).
-# Vercel handles deploys; this just keeps GitLab in sync for backup/compliance.
+# GitHub is canonical. This workflow converges the private GitLab disaster-
+# recovery repository to GitHub's complete branch-and-tag state.
 on:
   push:
-    branches:
-      - main
+  delete:
+  schedule:
+    - cron: '17 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gitlab-mirror-${{ github.repository }}
+  cancel-in-progress: false
 
 env:
   GITLAB_REPO: https://gitlab.com/aetheris-vision-group/aetheris-vision-project.git
 
 jobs:
   mirror:
-    name: Push to GitLab
+    name: Mirror branches and tags
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0   # full history so force-push preserves commits
+    timeout-minutes: 10
 
-      - name: Push to GitLab
+    steps:
+      - name: Check out the canonical branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Fetch the complete GitHub ref set
         run: |
-          git remote add gitlab https://oauth2:${{ secrets.GITLAB_TOKEN }}@${GITLAB_REPO#https://}
-          git push gitlab main --force
+          git fetch --force --prune --prune-tags origin \
+            '+refs/heads/*:refs/mirror/heads/*' \
+            '+refs/tags/*:refs/tags/*'
+
+      - name: Push the private GitLab mirror
+        env:
+          GITLAB_MIRROR_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GITLAB_MIRROR_TOKEN:-}" ]; then
+            echo "::error::GITLAB_MIRROR_TOKEN is not configured"
+            exit 1
+          fi
+
+          git remote add gitlab \
+            "https://oauth2:${GITLAB_MIRROR_TOKEN}@${GITLAB_REPO#https://}"
+          git push gitlab --force --prune \
+            'refs/mirror/heads/*:refs/heads/*' \
+            'refs/tags/*:refs/tags/*'


### PR DESCRIPTION
## Summary

- synchronize every GitHub branch and tag to this repository's private GitLab disaster-recovery mirror
- reconcile on pushes, deletions, a daily schedule, and manual dispatch
- prune refs removed from GitHub and serialize mirror runs
- use `GITLAB_MIRROR_TOKEN`, scoped only to GitLab `write_repository`

## Validation

- `actionlint`
- live GitLab Git read/write test with the scoped token
- exact GitHub/GitLab branch-and-tag parity audit

The mirror token expires on August 5, 2027. GitHub remains canonical; GitLab is the private recovery copy.
