### PR TITLE
fix(api): admin-gate uploads and Gmail OAuth, require CRON_SECRET, correct OG job statuses

### DIFF
--- a/src/app/admin/omni-gridder/page.tsx
+++ b/src/app/admin/omni-gridder/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { OmniGridderJobStatus } from '@/lib/omni-gridder-client'
 
 type RegridMethod = 'nearest' | 'bilinear' | 'conservative' | 'ewa'
 // No local list of "all methods": the compatibility matrix renders whatever the
@@ -55,7 +56,7 @@ interface DatasetView {
  */
 type Provenance = 'live' | 'verified'
 
-type RowStatus = 'idle' | 'submitting' | 'queued' | 'processing' | 'plotting' | 'succeeded' | 'failed'
+type RowStatus = 'idle' | 'submitting' | 'queued' | 'running' | 'plotting' | 'succeeded' | 'failed' | 'cancelled'
 
 interface JobDiagnostics {
   interpolation_method: string | null
@@ -68,14 +69,7 @@ interface JobDiagnostics {
   notes: string[] | null
 }
 
-interface JobStatusResponse {
-  job_id: string
-  processor_type: string
-  status: 'queued' | 'processing' | 'succeeded' | 'failed'
-  submitted_at: number
-  result_uri: string | null
-  error_message: string | null
-  diagnostics: JobDiagnostics | null
+interface JobStatusResponse extends OmniGridderJobStatus {
   nextJobId?: string
 }
 
@@ -140,6 +134,7 @@ function formatDuration(ms: number): string {
 }
 
 const POLL_INTERVAL_MS = 3000
+const MAX_POLL_ATTEMPTS = 200
 
 function idleRow(method: RegridMethod): MethodRow {
   return {
@@ -429,7 +424,8 @@ export default function OmniGridderDemoPage() {
     method: RegridMethod,
     chainPlot: boolean,
     isPlotJob: boolean,
-    lastStatus: string | null,
+    lastStatus: OmniGridderJobStatus['status'] | null,
+    attempt = 1,
   ): Promise<void> {
     let res: Response
     try {
@@ -442,10 +438,19 @@ export default function OmniGridderDemoPage() {
         : ''
       res = await fetch(`/api/admin/omni-gridder/status/${jobId}${qs}`)
     } catch {
+      if (attempt >= MAX_POLL_ATTEMPTS) {
+        const message = `Job polling timed out after ${MAX_POLL_ATTEMPTS} attempts`
+        log(message)
+        updateRow(method, { status: 'failed', errorMessage: message, completedAt: Date.now() })
+        return
+      }
       log(`Network error polling ${jobId} — retrying`)
       pollTimers.current.set(
         jobId,
-        setTimeout(() => pollJob(jobId, method, chainPlot, isPlotJob, lastStatus), POLL_INTERVAL_MS),
+        setTimeout(
+          () => pollJob(jobId, method, chainPlot, isPlotJob, lastStatus, attempt + 1),
+          POLL_INTERVAL_MS,
+        ),
       )
       return
     }
@@ -488,6 +493,18 @@ export default function OmniGridderDemoPage() {
           diagnostics: data.diagnostics,
         })
       }
+      return
+    }
+
+    if (data.status === 'cancelled') {
+      const message = data.error_message ?? 'Job was cancelled'
+      if (isPlotJob) setGlobalError(message)
+      updateRow(method, {
+        status: 'cancelled',
+        errorMessage: message,
+        completedAt: Date.now(),
+        diagnostics: data.diagnostics,
+      })
       return
     }
 
@@ -539,11 +556,20 @@ export default function OmniGridderDemoPage() {
     }
 
     if (!isPlotJob) {
-      updateRow(method, { status: data.status === 'processing' ? 'processing' : 'queued' })
+      updateRow(method, { status: data.status })
+    }
+    if (attempt >= MAX_POLL_ATTEMPTS) {
+      const message = `Job polling timed out after ${MAX_POLL_ATTEMPTS} attempts`
+      log(message)
+      updateRow(method, { status: 'failed', errorMessage: message, completedAt: Date.now() })
+      return
     }
     pollTimers.current.set(
       jobId,
-      setTimeout(() => pollJob(jobId, method, chainPlot, isPlotJob, data.status), POLL_INTERVAL_MS),
+      setTimeout(
+        () => pollJob(jobId, method, chainPlot, isPlotJob, data.status, attempt + 1),
+        POLL_INTERVAL_MS,
+      ),
     )
   }
 
@@ -657,7 +683,7 @@ export default function OmniGridderDemoPage() {
 
   const isRunning = activeMethods.some((m) => {
     const s = rows[m].status
-    return s === 'submitting' || s === 'queued' || s === 'processing' || s === 'plotting'
+    return s === 'submitting' || s === 'queued' || s === 'running' || s === 'plotting'
   })
 
   return (
@@ -864,14 +890,18 @@ export default function OmniGridderDemoPage() {
                       <td className="border-b border-white/5 py-2 pr-4">
                         <span
                           className={
-                            row.status === 'failed'
+                            row.status === 'failed' || row.status === 'cancelled'
                               ? 'text-red-400'
                               : row.status === 'succeeded'
                                 ? 'text-green-400'
                                 : 'text-gray-300'
                           }
                         >
-                          {row.status}
+                          {row.status === 'running'
+                            ? 'Running'
+                            : row.status === 'cancelled'
+                              ? 'Cancelled'
+                              : row.status}
                         </span>
                         {row.errorMessage && (
                           <div className="text-xs text-red-400 mt-1">{row.errorMessage}</div>

--- a/src/app/api/auth/gmail/callback/route.ts
+++ b/src/app/api/auth/gmail/callback/route.ts
@@ -1,22 +1,46 @@
 import { sql } from '@/lib/db'
+import { isAdmin, safeEqual, unauthorizedResponse } from '@/lib/admin-auth'
 import { NextRequest, NextResponse } from 'next/server'
 
+const GMAIL_OAUTH_STATE_COOKIE = 'av-gmail-oauth-state'
+
+function clearStateCookie(response: NextResponse): NextResponse {
+  response.cookies.delete(GMAIL_OAUTH_STATE_COOKIE)
+  return response
+}
+
 export async function GET(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
   const { searchParams } = request.nextUrl
   const code = searchParams.get('code')
-  const account = searchParams.get('state') // 'biz' or 'per'
+  const stateParts = (searchParams.get('state') ?? '').split(':')
+  const [account, nonce] = stateParts
   const error = searchParams.get('error')
+  const storedNonce = request.cookies.get(GMAIL_OAUTH_STATE_COOKIE)?.value
 
   const origin = request.nextUrl.origin
 
-  if (error || !code || (account !== 'biz' && account !== 'per')) {
-    return NextResponse.redirect(
-      `${origin}/admin/gmail?error=${error ?? 'invalid'}`
+  if (
+    stateParts.length !== 2 ||
+    (account !== 'biz' && account !== 'per') ||
+    !safeEqual(nonce, storedNonce)
+  ) {
+    return clearStateCookie(
+      NextResponse.json({ error: 'Invalid OAuth state' }, { status: 403 })
+    )
+  }
+
+  if (error || !code) {
+    return clearStateCookie(
+      NextResponse.redirect(`${origin}/admin/gmail?error=${error ?? 'invalid'}`)
     )
   }
 
   if (!process.env.GMAIL_CLIENT_ID || !process.env.GMAIL_CLIENT_SECRET) {
-    return NextResponse.redirect(`${origin}/admin/gmail?error=missing_gmail_client_config`)
+    return clearStateCookie(
+      NextResponse.redirect(`${origin}/admin/gmail?error=missing_gmail_client_config`)
+    )
   }
 
   const redirectUri = `${origin}/api/auth/gmail/callback`
@@ -35,8 +59,8 @@ export async function GET(request: NextRequest) {
   const tokens = await tokenRes.json()
 
   if (!tokens.refresh_token) {
-    return NextResponse.redirect(
-      `${origin}/admin/gmail?error=no_refresh_token`
+    return clearStateCookie(
+      NextResponse.redirect(`${origin}/admin/gmail?error=no_refresh_token`)
     )
   }
 
@@ -59,7 +83,7 @@ export async function GET(request: NextRequest) {
           updated_at   = NOW()
   `
 
-  return NextResponse.redirect(
-    `${origin}/admin/gmail?connected=${account}`
+  return clearStateCookie(
+    NextResponse.redirect(`${origin}/admin/gmail?connected=${account}`)
   )
 }

--- a/src/app/api/auth/gmail/start/route.ts
+++ b/src/app/api/auth/gmail/start/route.ts
@@ -1,8 +1,13 @@
+import crypto from 'crypto'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 import { NextRequest, NextResponse } from 'next/server'
 
 const SCOPE = 'https://www.googleapis.com/auth/gmail.readonly openid email'
+const GMAIL_OAUTH_STATE_COOKIE = 'av-gmail-oauth-state'
 
 export async function GET(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
   const account = request.nextUrl.searchParams.get('account')
   if (account !== 'biz' && account !== 'per') {
     return NextResponse.json({ error: 'account must be biz or per' }, { status: 400 })
@@ -12,6 +17,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(`${request.nextUrl.origin}/admin/gmail?error=missing_gmail_client_id`)
   }
 
+  const nonce = crypto.randomBytes(16).toString('hex')
   const redirectUri = `${request.nextUrl.origin}/api/auth/gmail/callback`
   const params = new URLSearchParams({
     client_id: process.env.GMAIL_CLIENT_ID,
@@ -21,7 +27,7 @@ export async function GET(request: NextRequest) {
     access_type: 'offline',
     prompt: 'consent select_account',
     include_granted_scopes: 'true',
-    state: account,
+    state: `${account}:${nonce}`,
   })
 
   const authUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params}`
@@ -30,7 +36,7 @@ export async function GET(request: NextRequest) {
   // copy/paste into Google Cloud Console → OAuth client → Authorized redirect URIs.
   // Usage: /api/auth/gmail/start?account=per&debug=1
   if (request.nextUrl.searchParams.get('debug') === '1') {
-    return NextResponse.json({
+    const response = NextResponse.json({
       ok: true,
       account,
       origin: request.nextUrl.origin,
@@ -38,9 +44,23 @@ export async function GET(request: NextRequest) {
       authUrl,
       hint: 'Ensure redirectUri is listed under Google Cloud → APIs & Services → Credentials → OAuth 2.0 Client IDs → Authorized redirect URIs.',
     })
+    response.cookies.set(GMAIL_OAUTH_STATE_COOKIE, nonce, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      maxAge: 10 * 60,
+      path: '/',
+    })
+    return response
   }
 
-  return NextResponse.redirect(
-    authUrl
-  )
+  const response = NextResponse.redirect(authUrl)
+  response.cookies.set(GMAIL_OAUTH_STATE_COOKIE, nonce, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    maxAge: 10 * 60,
+    path: '/',
+  })
+  return response
 }

--- a/src/app/api/auth/gmail/start/route.ts
+++ b/src/app/api/auth/gmail/start/route.ts
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest) {
     })
     response.cookies.set(GMAIL_OAUTH_STATE_COOKIE, nonce, {
       httpOnly: true,
-      secure: true,
+      secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       maxAge: 10 * 60,
       path: '/',

--- a/src/app/api/auth/gmail/status/route.ts
+++ b/src/app/api/auth/gmail/status/route.ts
@@ -1,7 +1,10 @@
 import { sql } from '@/lib/db'
-import { NextResponse } from 'next/server'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
+import { NextRequest, NextResponse } from 'next/server'
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
   const rows = await sql`SELECT account, email FROM oauth_tokens WHERE account IN ('biz', 'per')`
 
   const map = Object.fromEntries(

--- a/src/app/api/cron/receipts/route.ts
+++ b/src/app/api/cron/receipts/route.ts
@@ -258,10 +258,7 @@ function authorizeCron(request: NextRequest): boolean {
   const secret = process.env.CRON_SECRET
   const authHeader = request.headers.get('authorization')
   if (secret && authHeader === `Bearer ${secret}`) return true
-  // Vercel Cron sets this header on scheduled invocations.
-  // NOTE: Anyone could spoof this header, but the route is still guarded by the vendor allowlist,
-  // Gmail OAuth token presence, and idempotent inserts. If you want strict auth, keep CRON_SECRET.
-  if (request.headers.get('x-vercel-cron') === '1') return true
+  // Manual runs from /admin/gmail carry the admin session cookie.
   return isAdmin(request)
 }
 

--- a/src/app/api/receipts/upload/route.ts
+++ b/src/app/api/receipts/upload/route.ts
@@ -1,7 +1,10 @@
 import { put } from '@vercel/blob'
+import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function POST(request: NextRequest) {
+  if (!isAdmin(request)) return unauthorizedResponse()
+
   const form = await request.formData()
   const file = form.get('file') as File | null
 
@@ -9,8 +12,15 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'No file provided' }, { status: 400 })
   }
 
-  const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/heic', 'application/pdf']
-  if (!allowedTypes.includes(file.type)) {
+  const extensionsByMime: Record<string, string> = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/webp': 'webp',
+    'image/heic': 'heic',
+    'application/pdf': 'pdf',
+  }
+  const ext = extensionsByMime[file.type]
+  if (!ext) {
     return NextResponse.json({ error: 'Only images and PDFs are accepted' }, { status: 400 })
   }
 
@@ -19,7 +29,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'File must be under 10 MB' }, { status: 400 })
   }
 
-  const ext = file.name.split('.').pop() ?? 'bin'
   const filename = `receipts/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`
 
   const blob = await put(filename, file, { access: 'public' })

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -10,6 +10,16 @@ const resend = new Resend(process.env.RESEND_API_KEY)
 const RATE_LIMIT = 3
 const WINDOW_MS = 10 * 60 * 1000
 
+/** Escape user-supplied text before interpolating it into the HTML email. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
 export async function GET() {
   try {
     await ensureReviewsTable()
@@ -80,6 +90,10 @@ export async function POST(req: NextRequest) {
     try {
       const stars = '★'.repeat(rating) + '☆'.repeat(5 - rating)
       const adminUrl = `${process.env.NEXT_PUBLIC_SITE_URL ?? 'https://aetherisvision.com'}/admin/reviews`
+      const clientDetails = [client_role, client_company]
+        .filter((value): value is string => value !== null)
+        .map(escapeHtml)
+        .join(' · ')
       await resend.emails.send({
         from: 'system@aetherisvision.com',
         to: ['contact@aetherisvision.com'],
@@ -90,10 +104,10 @@ export async function POST(req: NextRequest) {
             <p style="color:#64748b;font-size:13px;margin-bottom:24px;">Pending your approval before it goes live.</p>
 
             <div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:20px 24px;margin-bottom:24px;">
-              <p style="margin:0 0 4px;color:#0f172a;font-size:16px;font-weight:600;">${client_name}</p>
-              ${client_role || client_company ? `<p style="margin:0 0 12px;color:#64748b;font-size:13px;">${[client_role, client_company].filter(Boolean).join(' · ')}</p>` : ''}
+              <p style="margin:0 0 4px;color:#0f172a;font-size:16px;font-weight:600;">${escapeHtml(client_name)}</p>
+              ${clientDetails ? `<p style="margin:0 0 12px;color:#64748b;font-size:13px;">${clientDetails}</p>` : ''}
               <p style="margin:0 0 12px;color:#f59e0b;font-size:18px;letter-spacing:2px;">${stars}</p>
-              <p style="margin:0;color:#334155;font-size:15px;line-height:1.6;">${reviewBody.replace(/</g, '&lt;').replace(/>/g, '&gt;')}</p>
+              <p style="margin:0;color:#334155;font-size:15px;line-height:1.6;">${escapeHtml(reviewBody)}</p>
             </div>
 
             <a href="${adminUrl}"

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { Resend } from 'resend'
 import { createReview, getApprovedReviews, ensureReviewsTable } from '@/lib/db/reviews'
 import { rateLimit } from '@/lib/rate-limit'
+import { SITE } from '@/lib/constants'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
@@ -89,7 +90,7 @@ export async function POST(req: NextRequest) {
     // Send notification email to admin (non-fatal)
     try {
       const stars = '★'.repeat(rating) + '☆'.repeat(5 - rating)
-      const adminUrl = `${process.env.NEXT_PUBLIC_SITE_URL ?? 'https://aetherisvision.com'}/admin/reviews`
+      const adminUrl = `${process.env.NEXT_PUBLIC_SITE_URL ?? SITE.url}/admin/reviews`
       const clientDetails = [client_role, client_company]
         .filter((value): value is string => value !== null)
         .map(escapeHtml)

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from './index'
 
+// Invoke explicitly from a setup script; this module must remain side-effect-free on import.
 export async function createTables() {
   await sql`
     CREATE TABLE IF NOT EXISTS expenses (
@@ -123,10 +124,24 @@ export async function createTables() {
       id          SERIAL PRIMARY KEY,
       client_id   INTEGER REFERENCES clients(id) ON DELETE CASCADE,
       project_id  INTEGER REFERENCES projects(id) ON DELETE SET NULL,
-      name        TEXT NOT NULL,
+      title       TEXT NOT NULL,
       content     TEXT,
       type        TEXT,
-      created_at  TIMESTAMPTZ DEFAULT NOW()
+      created_at  TIMESTAMPTZ DEFAULT NOW(),
+      updated_at  TIMESTAMPTZ DEFAULT NOW()
+    )
+  `
+
+  await sql`
+    CREATE TABLE IF NOT EXISTS reviews (
+      id             SERIAL PRIMARY KEY,
+      client_name    TEXT NOT NULL,
+      client_role    TEXT,
+      client_company TEXT,
+      rating         INTEGER NOT NULL CHECK (rating >= 1 AND rating <= 5),
+      body           TEXT NOT NULL,
+      approved       BOOLEAN NOT NULL DEFAULT false,
+      created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
   `
 
@@ -150,5 +165,3 @@ export async function createTables() {
 
   console.log('Tables created successfully')
 }
-
-createTables().catch(console.error)

--- a/src/lib/omni-gridder-client.ts
+++ b/src/lib/omni-gridder-client.ts
@@ -65,11 +65,11 @@ export interface OmniGridderJobDiagnostics {
 export interface OmniGridderJobStatus {
   job_id: string
   processor_type: string
-  status: 'queued' | 'processing' | 'succeeded' | 'failed'
+  status: 'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled'
   submitted_at: number
   result_uri: string | null
   error_message: string | null
-  // null for queued/processing/failed/legacy jobs pre-dating diagnostics support.
+  // null for queued/running/failed/cancelled/legacy jobs pre-dating diagnostics support.
   diagnostics: OmniGridderJobDiagnostics | null
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -77,12 +77,14 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next()
   }
 
-  // Site lock: the public site remains gated while Agentic OG is prepared for
-  // reliable demos and published results. A signed cookie avoids browser-native
+  // Site lock: the public site remains gated while the new consulting site is
+  // prepared for launch. A signed cookie avoids browser-native
   // Basic Auth dialogs, which do not work consistently in embedded browsers.
   // /admin/* retains its separate passphrase gate below.
   const isPreviewAccessRoute =
-    pathname === '/preview' || pathname === '/api/preview/auth'
+    pathname === '/preview' ||
+    pathname === '/api/preview/auth' ||
+    pathname === '/api/auth/gmail/callback'
   if (
     process.env.PREVIEW_PASSWORD &&
     !pathname.startsWith('/admin') &&

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -84,7 +84,9 @@ export async function proxy(request: NextRequest) {
   const isPreviewAccessRoute =
     pathname === '/preview' ||
     pathname === '/api/preview/auth' ||
-    pathname === '/api/auth/gmail/callback'
+    pathname === '/api/auth/gmail/callback' ||
+    pathname === '/api/auth/gmail/start' ||
+    pathname === '/api/auth/gmail/status'
   if (
     process.env.PREVIEW_PASSWORD &&
     !pathname.startsWith('/admin') &&


### PR DESCRIPTION
## Summary
- /api/receipts/upload: requires admin session; file extension now derives from the validated MIME type (client filename no longer trusted); public-blob upload abuse closed
- Gmail OAuth (start/callback/status): admin-gated; real per-request CSRF state nonce in an httpOnly cookie, constant-time compared and cleared on every path; /status no longer leaks connected mailbox addresses
- /api/cron/receipts: spoofable x-vercel-cron header fallback removed — Bearer CRON_SECRET or admin session only
- src/proxy.ts: OAuth callback exempted from the preview site lock (Gmail connect was broken while locked)
- Review notification email: all submitter-controlled fields HTML-escaped
- Omni Gridder statuses: union corrected to the values og-server actually emits (queued/running/succeeded/failed/cancelled) — running jobs no longer display as queued; cancelled is a terminal state; polling bounded at 200 attempts
- src/lib/db/schema.ts: documents name→title + updated_at reconciled with consumers; reviews table added; import-time DDL side effect removed

## Gates
- Unit 263/263, Cucumber 29/29, ESLint 0 errors, build PASS (all on rebased head)

🤖 Generated with [Claude Code](https://claude.com/claude-code)