### PR TITLE
refactor(seo): derive sitemap portfolio routes from portfolio-data demos

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from "next";
 import { posts } from "@/lib/posts";
+import { demos } from "@/lib/portfolio-data";
 import { SITE } from "@/lib/constants";
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -84,81 +85,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
   ];
 
-  // Portfolio demo pages
-  const demoRoutes: MetadataRoute.Sitemap = [
-    {
-      url: `${SITE.url}/portfolio/analytics-dashboard`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/fitness`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/healthcare`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/international-market`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/law-firm`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/photography-studio`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/portal-pro`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/real-estate`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/restaurant`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/trades-contractor`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/veteran-nonprofit`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/wp-editorial`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-  ];
+  // Portfolio demo pages — derived from the same source of truth as the
+  // /portfolio index listing (src/lib/portfolio-data.ts).
+  const demoRoutes: MetadataRoute.Sitemap = demos.map((demo) => ({
+    url: `${SITE.url}/portfolio/${demo.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly",
+    priority: 0.5,
+  }));
 
   const blogRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `${SITE.url}/blog/${post.slug}`,


### PR DESCRIPTION
## Summary
- Replaces the hardcoded 12-entry `demoRoutes` slug list in `src/app/sitemap.ts` (added in #96 — see the Copilot thread there) with `demos.map()` over `src/lib/portfolio-data.ts`.
- The `/portfolio` index page already renders from `demos`, and `demos` already covers all 12 demo routes (verified each title against its page under `src/app/portfolio/*`), so the listing and the sitemap now share one source of truth: add or remove a demo in `portfolio-data.ts` and both update automatically.
- Net −66 lines, no content/URL changes: the built `sitemap.xml` contains the identical 12 `/portfolio/<slug>` URLs as before.

## Testing
- `npm test` — 263 passed
- `npm run test:cucumber` — 29 scenarios / 106 steps passed
- `npm run lint` — 0 errors, 20 warnings (CI max is 24)
- `npm run build` — clean; verified all 12 demo URLs present in the generated `.next/server/app/sitemap.xml.body`

🤖 Generated with [Claude Code](https://claude.com/claude-code)