### PR TITLE
fix: address code-review findings from the consulting-launch push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,11 +39,14 @@ Uses `getToken()` not `getServerSession()` for App Router compatibility.
 
 ## Site Lock
 
-`src/proxy.ts` gates every route except `/admin/*` (which has its own passphrase gate),
-`/api/webhooks/*`, and `/api/cron/*` behind HTTP Basic Auth when `PREVIEW_PASSWORD` is set.
+`src/proxy.ts` gates every route behind a signed preview cookie (form at `/preview`;
+not browser-native Basic Auth) when `PREVIEW_PASSWORD` is set, except: `/admin/*`
+(its own passphrase gate), `/api/webhooks/*`, `/api/cron/*`, `/preview` +
+`/api/preview/auth` themselves, and `/api/auth/gmail/*` (each handler there enforces
+the admin session itself; Google's OAuth redirect cannot carry the preview cookie).
 Unset `PREVIEW_PASSWORD` = site fully open; this is opt-in, not opt-out.
 
-Re-locked 2026-07-03 while the site is retooled to focus on Agentic OG (omni-gridder).
+Re-locked 2026-07-03 while the site is retooled around the consulting-first launch.
 Value lives in Vercel env / `~/.secrets` — not hardcoded in the repo.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -11399,7 +11399,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/admin/omni-gridder/page.tsx
+++ b/src/app/admin/omni-gridder/page.tsx
@@ -419,6 +419,24 @@ export default function OmniGridderDemoPage() {
   //
   // isPlotJob=true means this poll loop is tracking the chained Plot job,
   // not the regrid job — its result renders the map, not a row update.
+  //
+  // Shared give-up path for both timeout sites in pollJob. Honors the same
+  // invariant as the failed/cancelled branches: a chained plot job's fate must
+  // never mark the already-succeeded regrid row as failed.
+  function failPollTimeout(method: RegridMethod, isPlotJob: boolean): void {
+    const message = `Job polling timed out after ${MAX_POLL_ATTEMPTS} attempts`
+    log(message)
+    if (isPlotJob) {
+      setGlobalError(message)
+      updateRow(method, {
+        errorMessage: 'Plot rendering timed out (regrid itself succeeded)',
+        status: 'succeeded',
+      })
+    } else {
+      updateRow(method, { status: 'failed', errorMessage: message, completedAt: Date.now() })
+    }
+  }
+
   async function pollJob(
     jobId: string,
     method: RegridMethod,
@@ -439,9 +457,7 @@ export default function OmniGridderDemoPage() {
       res = await fetch(`/api/admin/omni-gridder/status/${jobId}${qs}`)
     } catch {
       if (attempt >= MAX_POLL_ATTEMPTS) {
-        const message = `Job polling timed out after ${MAX_POLL_ATTEMPTS} attempts`
-        log(message)
-        updateRow(method, { status: 'failed', errorMessage: message, completedAt: Date.now() })
+        failPollTimeout(method, isPlotJob)
         return
       }
       log(`Network error polling ${jobId} — retrying`)
@@ -498,13 +514,23 @@ export default function OmniGridderDemoPage() {
 
     if (data.status === 'cancelled') {
       const message = data.error_message ?? 'Job was cancelled'
-      if (isPlotJob) setGlobalError(message)
-      updateRow(method, {
-        status: 'cancelled',
-        errorMessage: message,
-        completedAt: Date.now(),
-        diagnostics: data.diagnostics,
-      })
+      if (isPlotJob) {
+        // Same invariant as the failed branch above: the regrid already
+        // succeeded, so a cancelled plot job must not overwrite the row's
+        // status, completedAt, or diagnostics.
+        setGlobalError(message)
+        updateRow(method, {
+          errorMessage: 'Plot job was cancelled (regrid itself succeeded)',
+          status: 'succeeded',
+        })
+      } else {
+        updateRow(method, {
+          status: 'cancelled',
+          errorMessage: message,
+          completedAt: Date.now(),
+          diagnostics: data.diagnostics,
+        })
+      }
       return
     }
 
@@ -555,14 +581,16 @@ export default function OmniGridderDemoPage() {
       return
     }
 
-    if (!isPlotJob) {
-      updateRow(method, { status: data.status })
-    }
     if (attempt >= MAX_POLL_ATTEMPTS) {
-      const message = `Job polling timed out after ${MAX_POLL_ATTEMPTS} attempts`
-      log(message)
-      updateRow(method, { status: 'failed', errorMessage: message, completedAt: Date.now() })
+      failPollTimeout(method, isPlotJob)
       return
+    }
+    if (!isPlotJob) {
+      // Clamp to the known non-terminal statuses: a version-skewed backend
+      // emitting anything else (e.g. the retired 'processing') would leave the
+      // row on an unknown status, flip isRunning false mid-poll, and re-enable
+      // the Run buttons while this loop is still going.
+      updateRow(method, { status: data.status === 'running' ? 'running' : 'queued' })
     }
     pollTimers.current.set(
       jobId,

--- a/src/app/api/admin/documents/[id]/pdf/route.ts
+++ b/src/app/api/admin/documents/[id]/pdf/route.ts
@@ -8,6 +8,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 import { sql } from '@/lib/db'
+import { escapeHtml as escHtml } from '@/lib/escape-html'
 import { marked } from 'marked'
 import DOMPurify from 'isomorphic-dompurify'
 
@@ -203,12 +204,3 @@ export async function GET(
   })
 }
 
-/** Escape HTML special characters to prevent XSS in string interpolation */
-function escHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;')
-}

--- a/src/app/api/admin/invoices/[id]/send/route.ts
+++ b/src/app/api/admin/invoices/[id]/send/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
 import { sql } from '@/lib/db'
+import { escapeHtml as escHtml } from '@/lib/escape-html'
 import { stripe } from '@/lib/stripe'
 import { Resend } from 'resend'
 
@@ -173,12 +174,3 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   return NextResponse.json({ ok: true, invoice_url: invoiceUrl })
 }
 
-/** Escape HTML special characters to prevent injection in template strings */
-function escHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;')
-}

--- a/src/app/api/auth/gmail/callback/route.ts
+++ b/src/app/api/auth/gmail/callback/route.ts
@@ -1,45 +1,47 @@
 import { sql } from '@/lib/db'
 import { isAdmin, safeEqual, unauthorizedResponse } from '@/lib/admin-auth'
+import { clearStateCookie, stateCookieName } from '@/lib/gmail-oauth'
 import { NextRequest, NextResponse } from 'next/server'
-
-const GMAIL_OAUTH_STATE_COOKIE = 'av-gmail-oauth-state'
-
-function clearStateCookie(response: NextResponse): NextResponse {
-  response.cookies.delete(GMAIL_OAUTH_STATE_COOKIE)
-  return response
-}
 
 export async function GET(request: NextRequest) {
   if (!isAdmin(request)) return unauthorizedResponse()
 
   const { searchParams } = request.nextUrl
   const code = searchParams.get('code')
+  const error = searchParams.get('error')
   const stateParts = (searchParams.get('state') ?? '').split(':')
   const [account, nonce] = stateParts
-  const error = searchParams.get('error')
-  const storedNonce = request.cookies.get(GMAIL_OAUTH_STATE_COOKIE)?.value
 
   const origin = request.nextUrl.origin
 
-  if (
-    stateParts.length !== 2 ||
-    (account !== 'biz' && account !== 'per') ||
-    !safeEqual(nonce, storedNonce)
-  ) {
+  if (account !== 'biz' && account !== 'per') {
+    return NextResponse.redirect(`${origin}/admin/gmail?error=invalid_state`)
+  }
+
+  // Google reports user-denied consent (and similar) with no code. No token
+  // exchange happens on this path, so surface it before the nonce check — an
+  // expired state cookie must not turn a plain "Cancel" into a dead end.
+  if (error || !code) {
     return clearStateCookie(
-      NextResponse.json({ error: 'Invalid OAuth state' }, { status: 403 })
+      NextResponse.redirect(
+        `${origin}/admin/gmail?error=${encodeURIComponent(error ?? 'invalid')}`
+      ),
+      account
     )
   }
 
-  if (error || !code) {
+  const storedNonce = request.cookies.get(stateCookieName(account))?.value
+  if (stateParts.length !== 2 || !safeEqual(nonce, storedNonce)) {
     return clearStateCookie(
-      NextResponse.redirect(`${origin}/admin/gmail?error=${error ?? 'invalid'}`)
+      NextResponse.redirect(`${origin}/admin/gmail?error=invalid_state`),
+      account
     )
   }
 
   if (!process.env.GMAIL_CLIENT_ID || !process.env.GMAIL_CLIENT_SECRET) {
     return clearStateCookie(
-      NextResponse.redirect(`${origin}/admin/gmail?error=missing_gmail_client_config`)
+      NextResponse.redirect(`${origin}/admin/gmail?error=missing_gmail_client_config`),
+      account
     )
   }
 
@@ -60,7 +62,8 @@ export async function GET(request: NextRequest) {
 
   if (!tokens.refresh_token) {
     return clearStateCookie(
-      NextResponse.redirect(`${origin}/admin/gmail?error=no_refresh_token`)
+      NextResponse.redirect(`${origin}/admin/gmail?error=no_refresh_token`),
+      account
     )
   }
 
@@ -84,6 +87,7 @@ export async function GET(request: NextRequest) {
   `
 
   return clearStateCookie(
-    NextResponse.redirect(`${origin}/admin/gmail?connected=${account}`)
+    NextResponse.redirect(`${origin}/admin/gmail?connected=${account}`),
+    account
   )
 }

--- a/src/app/api/auth/gmail/start/route.ts
+++ b/src/app/api/auth/gmail/start/route.ts
@@ -1,9 +1,9 @@
 import crypto from 'crypto'
 import { isAdmin, unauthorizedResponse } from '@/lib/admin-auth'
+import { setStateCookie } from '@/lib/gmail-oauth'
 import { NextRequest, NextResponse } from 'next/server'
 
 const SCOPE = 'https://www.googleapis.com/auth/gmail.readonly openid email'
-const GMAIL_OAUTH_STATE_COOKIE = 'av-gmail-oauth-state'
 
 export async function GET(request: NextRequest) {
   if (!isAdmin(request)) return unauthorizedResponse()
@@ -44,23 +44,8 @@ export async function GET(request: NextRequest) {
       authUrl,
       hint: 'Ensure redirectUri is listed under Google Cloud → APIs & Services → Credentials → OAuth 2.0 Client IDs → Authorized redirect URIs.',
     })
-    response.cookies.set(GMAIL_OAUTH_STATE_COOKIE, nonce, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 10 * 60,
-      path: '/',
-    })
-    return response
+    return setStateCookie(response, request, account, nonce)
   }
 
-  const response = NextResponse.redirect(authUrl)
-  response.cookies.set(GMAIL_OAUTH_STATE_COOKIE, nonce, {
-    httpOnly: true,
-    secure: true,
-    sameSite: 'lax',
-    maxAge: 10 * 60,
-    path: '/',
-  })
-  return response
+  return setStateCookie(NextResponse.redirect(authUrl), request, account, nonce)
 }

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { SITE } from "@/lib/constants";
 import { rateLimit } from "@/lib/rate-limit";
+import { escapeHtml } from "@/lib/escape-html";
 
 // Contact submissions are delivered by email through Resend — the same
 // provider already used for magic-link sign-in and invoice delivery. This
@@ -26,16 +27,6 @@ function asString(value: unknown): string {
 /** Collapse CR/LF so untrusted values cannot inject email header lines. */
 function singleLine(value: string, max: number): string {
   return value.replace(/[\r\n]+/g, " ").trim().slice(0, max);
-}
-
-/** Escape user-supplied text before interpolating it into the HTML email. */
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 export async function POST(req: NextRequest) {

--- a/src/app/api/reviews/route.ts
+++ b/src/app/api/reviews/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { Resend } from 'resend'
 import { createReview, getApprovedReviews, ensureReviewsTable } from '@/lib/db/reviews'
 import { rateLimit } from '@/lib/rate-limit'
+import { escapeHtml } from '@/lib/escape-html'
 import { SITE } from '@/lib/constants'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
@@ -10,16 +11,6 @@ const resend = new Resend(process.env.RESEND_API_KEY)
 // instances when Upstash/Vercel KV is configured, else in-memory (issue #12).
 const RATE_LIMIT = 3
 const WINDOW_MS = 10 * 60 * 1000
-
-/** Escape user-supplied text before interpolating it into the HTML email. */
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-}
 
 export async function GET() {
   try {

--- a/src/app/capabilities/opengraph-image.tsx
+++ b/src/app/capabilities/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { SITE } from "@/lib/constants";
+import { SAM, SITE } from "@/lib/constants";
 import { AV_MARK_DATA_URI } from "../og-mark";
 
 export const runtime = "edge";
@@ -15,7 +15,7 @@ const badgeStyle = {
   padding: "6px 16px",
 } as const;
 
-const badges = ["SAM.gov Active", "UEI and CAGE Assigned", "SDVOSB / HUBZone Pending"];
+const badges = ["SAM.gov Active", "UEI and CAGE Assigned", ...SAM.setAsidePills];
 
 export default function OGImage() {
   return new ImageResponse(

--- a/src/app/capabilities/page.tsx
+++ b/src/app/capabilities/page.tsx
@@ -18,7 +18,7 @@ const companyData: { label: string; value: ReactNode }[] = [
   { label: "Primary NAICS", value: `${SAM.naicsPrimary}: Scientific & Technical Consulting` },
   {
     label: "Certifications",
-    value: "SDVOSB/VOSB eligible; SBA VetCert pending. HUBZone eligible; certification pending.",
+    value: SAM.setAsidePills.join(". "),
   },
   { label: "Security Clearance", value: "Active U.S. Government Secret, held by principal" },
   {
@@ -92,8 +92,7 @@ const competencies = [
     title: "Federal Registrations",
     items: [
       `SAM.gov registered: UEI ${SAM.uei}, CAGE ${SAM.cage}`,
-      "SDVOSB/VOSB eligible; SBA VetCert application pending",
-      "HUBZone eligible; certification pending",
+      ...SAM.setAsidePills,
       "Oklahoma Supplier Portal: state-level contracting access (registration in progress)",
       "Active U.S. Government Secret clearance held by the principal",
     ],

--- a/src/app/og-card.tsx
+++ b/src/app/og-card.tsx
@@ -1,0 +1,43 @@
+import { ImageResponse } from "next/og";
+import { SITE } from "@/lib/constants";
+import { AV_MARK_DATA_URI } from "./og-mark";
+
+export const OG_SIZE = { width: 1200, height: 630 };
+
+/**
+ * Shared 1200×630 OG card: gradient ground, AV mark + wordmark row, title,
+ * subtitle. Route opengraph-image files keep their own metadata exports and
+ * call this instead of copy-pasting the JSX shell.
+ */
+export function ogCard(title: string, subtitle: string): ImageResponse {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "linear-gradient(135deg, #050505 0%, #0e1726 50%, #050505 100%)",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "16px", marginBottom: "24px" }}>
+          <img src={AV_MARK_DATA_URI} width={64} height={64} alt="" />
+          <span style={{ fontSize: "18px", letterSpacing: "4px", color: "#5BA8D9", textTransform: "uppercase", fontWeight: 600 }}>
+            {SITE.name}
+          </span>
+        </div>
+        <h1 style={{ fontSize: "64px", fontWeight: 700, color: "#ffffff", lineHeight: 1.1, margin: 0, letterSpacing: "-2px" }}>
+          {title}
+        </h1>
+        <p style={{ fontSize: "22px", color: "#9ca3af", marginTop: "28px", maxWidth: "700px", lineHeight: 1.5 }}>
+          {subtitle}
+        </p>
+      </div>
+    ),
+    { ...OG_SIZE }
+  );
+}

--- a/src/app/omni-gridder/opengraph-image.tsx
+++ b/src/app/omni-gridder/opengraph-image.tsx
@@ -1,41 +1,11 @@
-import { ImageResponse } from "next/og";
 import { SITE } from "@/lib/constants";
-import { AV_MARK_DATA_URI } from "../og-mark";
+import { ogCard, OG_SIZE } from "../og-card";
 
 export const runtime = "edge";
 export const alt = `Omni Gridder | ${SITE.name}`;
-export const size = { width: 1200, height: 630 };
+export const size = OG_SIZE;
 export const contentType = "image/png";
 
 export default function OGImage() {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          background: "linear-gradient(135deg, #050505 0%, #0e1726 50%, #050505 100%)",
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          padding: "80px",
-          fontFamily: "system-ui, sans-serif",
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: "16px", marginBottom: "24px" }}>
-          <img src={AV_MARK_DATA_URI} width={64} height={64} alt="" />
-          <span style={{ fontSize: "18px", letterSpacing: "4px", color: "#5BA8D9", textTransform: "uppercase", fontWeight: 600 }}>
-            {SITE.name}
-          </span>
-        </div>
-        <h1 style={{ fontSize: "64px", fontWeight: 700, color: "#ffffff", lineHeight: 1.1, margin: 0, letterSpacing: "-2px" }}>
-          Omni Gridder
-        </h1>
-        <p style={{ fontSize: "22px", color: "#9ca3af", marginTop: "28px", maxWidth: "700px", lineHeight: 1.5 }}>
-          A featured example of Earth-data transformation
-        </p>
-      </div>
-    ),
-    { ...size }
-  );
+  return ogCard("Omni Gridder", "A featured example of Earth-data transformation");
 }

--- a/src/app/services/opengraph-image.tsx
+++ b/src/app/services/opengraph-image.tsx
@@ -1,41 +1,11 @@
-import { ImageResponse } from "next/og";
 import { SITE } from "@/lib/constants";
-import { AV_MARK_DATA_URI } from "../og-mark";
+import { ogCard, OG_SIZE } from "../og-card";
 
 export const runtime = "edge";
 export const alt = `Services | ${SITE.name}`;
-export const size = { width: 1200, height: 630 };
+export const size = OG_SIZE;
 export const contentType = "image/png";
 
 export default function OGImage() {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          background: "linear-gradient(135deg, #050505 0%, #0e1726 50%, #050505 100%)",
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "center",
-          padding: "80px",
-          fontFamily: "system-ui, sans-serif",
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: "16px", marginBottom: "24px" }}>
-          <img src={AV_MARK_DATA_URI} width={64} height={64} alt="" />
-          <span style={{ fontSize: "18px", letterSpacing: "4px", color: "#5BA8D9", textTransform: "uppercase", fontWeight: 600 }}>
-            {SITE.name}
-          </span>
-        </div>
-        <h1 style={{ fontSize: "64px", fontWeight: 700, color: "#ffffff", lineHeight: 1.1, margin: 0, letterSpacing: "-2px" }}>
-          Services
-        </h1>
-        <p style={{ fontSize: "22px", color: "#9ca3af", marginTop: "28px", maxWidth: "700px", lineHeight: 1.5 }}>
-          Scientific consulting, carried through to delivery
-        </p>
-      </div>
-    ),
-    { ...size }
-  );
+  return ogCard("Services", "Scientific consulting, carried through to delivery");
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from "next";
 import { posts } from "@/lib/posts";
 import { SITE } from "@/lib/constants";
+import { demos } from "@/lib/portfolio-data";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes: MetadataRoute.Sitemap = [
@@ -77,6 +78,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.4,
     },
     {
+      url: `${SITE.url}/security`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
       url: `${SITE.url}/privacy`,
       lastModified: new Date(),
       changeFrequency: "yearly",
@@ -84,81 +91,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
   ];
 
-  // Portfolio demo pages
-  const demoRoutes: MetadataRoute.Sitemap = [
-    {
-      url: `${SITE.url}/portfolio/analytics-dashboard`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/fitness`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/healthcare`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/international-market`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/law-firm`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/photography-studio`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/portal-pro`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/real-estate`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/restaurant`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/trades-contractor`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/veteran-nonprofit`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-    {
-      url: `${SITE.url}/portfolio/wp-editorial`,
-      lastModified: new Date(),
-      changeFrequency: "monthly",
-      priority: 0.5,
-    },
-  ];
+  // Portfolio demo pages — derived from the canonical demo list so the
+  // sitemap cannot drift from what /portfolio actually renders.
+  const demoRoutes: MetadataRoute.Sitemap = demos.map((demo) => ({
+    url: `${SITE.url}/portfolio/${demo.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly",
+    priority: 0.5,
+  }));
 
   const blogRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
     url: `${SITE.url}/blog/${post.slug}`,

--- a/src/lib/escape-html.ts
+++ b/src/lib/escape-html.ts
@@ -1,0 +1,13 @@
+/**
+ * Escape user- or database-supplied text before interpolating it into HTML
+ * (notification emails, generated PDFs). Single shared implementation — the
+ * routes building HTML from untrusted text must all use this one.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/src/lib/gmail-oauth.ts
+++ b/src/lib/gmail-oauth.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export type GmailAccount = 'biz' | 'per'
+
+// Per-account cookie: starting a second connect flow (e.g. `biz` and `per`
+// in two tabs) must not clobber the other flow's pending nonce.
+export function stateCookieName(account: GmailAccount): string {
+  return `av-gmail-oauth-state-${account}`
+}
+
+export function setStateCookie(
+  response: NextResponse,
+  request: NextRequest,
+  account: GmailAccount,
+  nonce: string
+): NextResponse {
+  response.cookies.set(stateCookieName(account), nonce, {
+    httpOnly: true,
+    // Protocol-aware like the admin session cookie: a Secure cookie set over
+    // plain-http dev is dropped by the browser, and the callback nonce check
+    // could then never pass.
+    secure: new URL(request.url).protocol === 'https:',
+    sameSite: 'lax',
+    maxAge: 10 * 60,
+    path: '/',
+  })
+  return response
+}
+
+export function clearStateCookie(
+  response: NextResponse,
+  account: GmailAccount
+): NextResponse {
+  response.cookies.delete(stateCookieName(account))
+  return response
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -88,11 +88,11 @@ For the full technical implementation details, contact us for a complete securit
       initials: "MW",
     },
     summary:
-      "Real-time performance monitoring with live Core Web Vitals analysis, memory profiling, and optimization strategies that deliver measurable user experience improvements.",
+      "An engineering overview of Core Web Vitals, performance budgets, and the optimization strategies that deliver measurable user experience improvements.",
     content: `
 Performance isn't just about fast page loads. It's about **predictable, reliable systems that scale under real-world conditions**. After a career spanning USAF operational weather, European research institutes, and industry software delivery, I've learned that true performance engineering requires understanding what actually affects user experience, not just optimizing for benchmark scores.
 
-This website's performance dashboard demonstrates these principles in production, providing real-time analysis of every metric that matters.
+This site is built and maintained to these principles, with attention to every metric that affects real user experience.
 
 ## Beyond Synthetic Testing: Real-Time Performance Analysis
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -81,12 +81,12 @@ export async function proxy(request: NextRequest) {
   // prepared for launch. A signed cookie avoids browser-native
   // Basic Auth dialogs, which do not work consistently in embedded browsers.
   // /admin/* retains its separate passphrase gate below.
+  // Every handler under /api/auth/gmail/ enforces isAdmin itself, so the whole
+  // prefix bypasses the site lock — new routes there must keep that guarantee.
   const isPreviewAccessRoute =
     pathname === '/preview' ||
     pathname === '/api/preview/auth' ||
-    pathname === '/api/auth/gmail/callback' ||
-    pathname === '/api/auth/gmail/start' ||
-    pathname === '/api/auth/gmail/status'
+    pathname.startsWith('/api/auth/gmail/')
   if (
     process.env.PREVIEW_PASSWORD &&
     !pathname.startsWith('/admin') &&

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -14,7 +14,7 @@ async function gotoReady(page: Page, route: string) {
 
 const publicRoutes = [
   "/",
-  "/agentic-og",
+  "/omni-gridder",
   "/about",
   "/services",
   "/services/web",
@@ -43,7 +43,7 @@ for (const route of publicRoutes) {
 }
 
 test("navigation switches cleanly between desktop and compact layouts", async ({ page }) => {
-  await gotoReady(page, "/agentic-og");
+  await gotoReady(page, "/omni-gridder");
   const viewport = page.viewportSize();
   expect(viewport).not.toBeNull();
 

--- a/tests/integration/omni-gridder-api.test.ts
+++ b/tests/integration/omni-gridder-api.test.ts
@@ -209,8 +209,8 @@ describe("GET /api/admin/omni-gridder/status/[jobId] — chainPlot gating", () =
     expect(submitJobMock).not.toHaveBeenCalled();
   });
 
-  it("does not chain a Plot job for a still-processing regrid job even with chainPlot=1", async () => {
-    getJobStatusMock.mockResolvedValue({ ...baseStatus, status: "processing", result_uri: null });
+  it("does not chain a Plot job for a still-running regrid job even with chainPlot=1", async () => {
+    getJobStatusMock.mockResolvedValue({ ...baseStatus, status: "running", result_uri: null });
     const { GET } = await importStatusRoute();
 
     const req = new NextRequest(
@@ -333,7 +333,7 @@ describe("GET /api/admin/omni-gridder/download", () => {
     getJobStatusMock.mockResolvedValue({
       job_id: PLOT_JOB_ID,
       processor_type: "plot",
-      status: "processing",
+      status: "running",
       submitted_at: Date.now(),
       result_uri: null,
       error_message: null,


### PR DESCRIPTION
Follow-up to the nine commits pushed to `main` (8563c64…7c92782). A 10-angle review of that range surfaced 15 findings; this PR fixes the code-level ones.

## Correctness
- **omni-gridder admin (`pollJob`)** — a cancelled or timed-out chained plot job no longer overwrites the succeeded regrid row: status stays `succeeded` with a note, `completedAt`/diagnostics are preserved, and the plot problem surfaces via `setGlobalError`. Both `MAX_POLL_ATTEMPTS` sites now share one `failPollTimeout` helper, and polled statuses are clamped to the known non-terminal set so a version-skewed backend can't flip `isRunning` false mid-poll and re-enable the Run buttons.
- **Gmail OAuth** — the state cookie is now per-account (`av-gmail-oauth-state-{biz,per}`), so starting a second connect flow can't clobber the first; the `secure` flag is protocol-aware like the admin session cookie (the hardcoded `secure: true` made every plain-http dev callback fail 403); Google error redirects (user Cancel) are handled before the nonce check; and state failures redirect to `/admin/gmail?error=invalid_state` instead of dead-ending on bare 403 JSON. Cookie name + set/clear helpers live in the new `src/lib/gmail-oauth.ts`.

## Tests
- e2e responsive suite targets `/omni-gridder` instead of riding the deleted `/agentic-og` route's 308.
- omni-gridder integration mocks use the real `running` status instead of the retired `processing`.

## Cleanup
- One shared `escapeHtml` (`src/lib/escape-html.ts`) replaces four private copies (reviews, contact, invoice send, document PDF).
- Sitemap portfolio entries derive from the `demos` export in `portfolio-data.ts`; `/security` added (it's the target of the `/security-status` 308).
- Capabilities page + OG badges source certification status from `SAM.setAsidePills` (was hardcoded in three places despite the "single source of truth" comment).
- Shared `og-card` factory for the two new opengraph images.
- Proxy site-lock exemption is a `/api/auth/gmail/` prefix match; `CLAUDE.md` site-lock section updated to match reality (cookie gate, current exemption list).

## Verified
`tsc --noEmit` clean · `eslint src/` 0 errors · `vitest run` 263/263 across 25 files. Playwright e2e not run (needs a live server); the two changed specs are route-string swaps.

## Deliberately not in this PR
- `createTables()` in `src/lib/db/schema.ts` still has no caller — the uncommitted local `scripts/migrate.ts` work appears to be the intended home; left to that branch.
- Whether `/api/expenses`, `/api/receipts/upload`, `/api/admin/*` should also bypass the preview gate (admin-cookie holders without the preview cookie currently get 307'd) — design call, flagged in the review.
- The five older opengraph-image files were not refactored onto `og-card` (kept the diff minimal); `/api-docs` + `/metrics` 307 stubs vs. config 308s also left as-is.
- `CRON_SECRET` was verified present in Vercel production, so the cron hardening from the reviewed push is safe as shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)